### PR TITLE
Home module

### DIFF
--- a/src/Service.Host/Startup.cs
+++ b/src/Service.Host/Startup.cs
@@ -31,7 +31,7 @@ namespace Linn.Stores.Service.Host
                 options =>
                     {
                         options.Authority = ConfigurationManager.Configuration["AUTHORITY_URI"];
-                        options.CallbackPath = new PathString("/stores/signin-oidc");
+                        options.CallbackPath = new PathString("/inventory/signin-oidc");
                     });
         }
 

--- a/src/Service.Host/client/src/components/Root.js
+++ b/src/Service.Host/client/src/components/Root.js
@@ -22,7 +22,7 @@ const Root = ({ store }) => (
                             <Navigation />
                             <CssBaseline />
 
-                            <Route exact path="/" render={() => <Redirect to="/stores" />} />
+                            <Route exact path="/" render={() => <Redirect to="/inventory" />} />
 
                             <Route
                                 path="/"
@@ -33,11 +33,11 @@ const Root = ({ store }) => (
                             />
 
                             <Switch>
-                                <Route exact path="/stores" component={App} />
+                                <Route exact path="/inventory" component={App} />
 
                                 <Route
                                     exact
-                                    path="/stores/signin-oidc-client"
+                                    path="/inventory/signin-oidc-client"
                                     component={Callback}
                                 />
                             </Switch>

--- a/src/Service.Host/client/src/helpers/userManager.js
+++ b/src/Service.Host/client/src/helpers/userManager.js
@@ -8,9 +8,9 @@ const oidcConfig = {
     client_id: 'app',
     response_type: 'id_token token',
     scope: 'openid profile email associations',
-    redirect_uri: `${host}/stores/signin-oidc-client`,
+    redirect_uri: `${host}/inventory/signin-oidc-client`,
     post_logout_redirect_uri: `${host}`,
-    silent_redirect_uri: `${host}/stores/signin-oidc-silent`,
+    silent_redirect_uri: `${host}/inventory/signin-oidc-silent`,
     automaticSilentRenew: true,
     filterProtocolClaims: true,
     loadUserInfo: true

--- a/src/Service.Host/client/src/index.js
+++ b/src/Service.Host/client/src/index.js
@@ -28,7 +28,7 @@ const render = Component => {
     );
 };
 
-if ((!user || user.expired) && window.location.pathname !== '/stores/signin-oidc-client') {
+if ((!user || user.expired) && window.location.pathname !== '/inventory/signin-oidc-client') {
     userManager.signinRedirect({
         data: { redirect: window.location.pathname + window.location.search }
     });

--- a/src/Service/Modules/HomeModule.cs
+++ b/src/Service/Modules/HomeModule.cs
@@ -1,0 +1,32 @@
+﻿namespace Linn.Stores.Service.Modules
+{
+    using Linn.Stores.Service.Models;
+
+    using Nancy;
+    using Nancy.Responses;
+
+    public sealed class HomeModule : NancyModule
+    {
+        public HomeModule()
+        {
+            this.Get("/", args => new RedirectResponse("/inventory"));
+            this.Get("/inventory", _ => this.GetApp());
+            this.Get("/inventory/(.*)/create", _ => this.GetApp());
+
+            this.Get("/inventory/signin-oidc-client", _ => this.GetApp());
+            this.Get("/inventory/signin-oidc-silent", _ => this.SilentRenew());
+
+            this.Get(@"^(.*)$", _ => this.GetApp());
+        }
+
+        private object SilentRenew()
+        {
+            return this.Negotiate.WithView("silent-renew");
+        }
+
+        private object GetApp()
+        {
+            return this.Negotiate.WithModel(ApplicationSettings.Get()).WithView("Index");
+        }
+    }
+}


### PR DESCRIPTION
 - using inventory now as a sort of catch all term for the menus this sln will incorporate, e.g. inventory/stock, inventory/logistics, inventory/materials-handling

- i've given up on typescript just now - template has quite a few moving parts with respect to javascript, babel, webpack et al and I couldn't figure out how to get it working this morning. I might try it out on the components library at some point seeing as it is a bit simpler

- anyway, after this pr gets merged the project should be good to go? I'm going to start on a form proper this afternoon 