### PR TITLE
fix wwd report ordering

### DIFF
--- a/src/Domain.LinnApps/Reports/WhatWillDecrementReportService.cs
+++ b/src/Domain.LinnApps/Reports/WhatWillDecrementReportService.cs
@@ -58,8 +58,6 @@
                 wwdWorks = wwdWorks.Where(w => w.QuantityKitted > w.QuantityAtLocation).ToList();
             }
 
-            wwdWorks.OrderBy(w => w.StoragePlace).ThenBy(w => w.PartNumber);
-
             var wwdWorkDetails = this.wwdWorkDetailsRepository.FilterBy(w => w.JobId == jobId).ToList();
 
             changeRequests = changeRequests.Where(c => wwdWorks.Any(w => w.PartNumber == c.OldPartNumber)).ToList();
@@ -74,7 +72,10 @@
 
             model.AddSortedColumns(columns);
 
-            var values = this.SetModelRows(wwdWorks, wwdWorkDetails, changeRequests);
+            var values = this.SetModelRows(
+                wwdWorks.OrderBy(w => w.StoragePlace == null).ThenBy(w => w.StoragePlace).ThenBy(w => w.PartNumber),
+                wwdWorkDetails,
+                changeRequests);
 
             this.reportingHelper.AddResultsToModel(model, values, CalculationValueModelType.Quantity, true);
 

--- a/src/Domain.LinnApps/Reports/WhatWillDecrementReportService.cs
+++ b/src/Domain.LinnApps/Reports/WhatWillDecrementReportService.cs
@@ -72,10 +72,10 @@
 
             model.AddSortedColumns(columns);
 
-            var values = this.SetModelRows(
-                wwdWorks.OrderBy(w => w.StoragePlace == null).ThenBy(w => w.StoragePlace).ThenBy(w => w.PartNumber),
-                wwdWorkDetails,
-                changeRequests);
+            var sortedWwdWorks = wwdWorks.OrderBy(w => w.StoragePlace == null).ThenBy(w => w.StoragePlace)
+                .ThenBy(w => w.PartNumber);
+
+            var values = this.SetModelRows(sortedWwdWorks, wwdWorkDetails, changeRequests);
 
             this.reportingHelper.AddResultsToModel(model, values, CalculationValueModelType.Quantity, true);
 


### PR DESCRIPTION
Bit of a weird looking ordering work around to get the empty strings to appear at the end of the sorted items (otherwise they would appear first and then the a-z sorted list). 

https://stackoverflow.com/a/36507021