### PR TITLE
Parcel ut - stop filtering suppliers/carriers that get passed in

### DIFF
--- a/src/Service.Host/client/src/containers/parcels/Parcels.js
+++ b/src/Service.Host/client/src/containers/parcels/Parcels.js
@@ -12,8 +12,7 @@ import { getPrivileges } from '../../selectors/userSelectors';
 const mapStateToProps = state => ({
     items: parcelsSelectors.getItems(state),
     loading: parcelsSelectors.getLoading(state),
-    suppliers: suppliersSelectors.getItems(state).filter(x => x.countryCode !== 'GB'),
-    carriers: suppliersSelectors.getItems(state).filter(x => x.approvedCarrier === 'Y'),
+    suppliers: suppliersSelectors.getItems(state),
     privileges: getPrivileges(state),
     suppliersSearchResults: suppliersSelectors
         .getSearchItems(state)


### PR DESCRIPTION
Was causing name to not be displayed for some carriers. Spent faaar too long thinking it was weird js type comparison going wrong before I checked the container 👎 