### PR TITLE
Shipfile optimisations

### DIFF
--- a/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
+++ b/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
@@ -49,21 +49,19 @@
             this.packingListService = packingListService;
         }
 
-        public IEnumerable<ConsignmentShipfile> SendEmails(
-            IEnumerable<ConsignmentShipfile> toSend, 
+        public ConsignmentShipfile SendEmails(
+           ConsignmentShipfile toSend, 
             bool test = false,
             string testEmailAddress = null)
         {
-            var withDetails = new List<ConsignmentShipfile>();
-            foreach (var shipfile in toSend)
-            {
-                var data = this.shipfileRepository.FindById(shipfile.Id);
+            var withDetails = new ConsignmentShipfile();
+            
+                var data = this.shipfileRepository.FindById(toSend.Id);
                 
                 if (data.ShipfileSent == "Y")
                 {
                     data.Message = ShipfileStatusMessages.EmailAlreadySent;
-                    withDetails.Add(data);
-                    continue;
+                    withDetails = data;
                 }
 
                 var models = this.BuildEmailModels(data);
@@ -105,9 +103,7 @@
                     }
                 }
 
-                withDetails.Add(data);
-            }
-
+                
             return withDetails;
         }
 

--- a/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
+++ b/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
@@ -60,6 +60,7 @@
             if (data.ShipfileSent == "Y")
             {
                 withDetails.Message = ShipfileStatusMessages.EmailAlreadySent;
+                return withDetails;
             }
 
             var models = this.BuildEmailModels(data);

--- a/src/Domain.LinnApps/ConsignmentShipfiles/IConsignmentShipfileService.cs
+++ b/src/Domain.LinnApps/ConsignmentShipfiles/IConsignmentShipfileService.cs
@@ -4,9 +4,6 @@
 
     public interface IConsignmentShipfileService
     {
-        IEnumerable<ConsignmentShipfile> SendEmails(
-            IEnumerable<ConsignmentShipfile> toSend, 
-            bool test = false,
-            string testEmailAddress = null);
+        ConsignmentShipfile SendEmails(ConsignmentShipfile toSend, bool test = false, string testEmailAddress = null);
     }
 }

--- a/src/Domain.LinnApps/ConsignmentShipfiles/PackingListService.cs
+++ b/src/Domain.LinnApps/ConsignmentShipfiles/PackingListService.cs
@@ -27,14 +27,22 @@
                 }
                
                 // the first item we see, so add it to a new group unless it is the <<__ End of Input __> delimiter returned by the query
-                if (i == 0 && current.ContentsDescription != "<<__ End of input __>>")
+                if (i == 0)
                 {
-                    resultGroups.Add(new PackingListItem(current.Pallet, current.Box, current.ContentsDescription, current.Quantity)
-                                         {
-                                             Count = current.Box,
-                                             To = current.Box
-                                         });
-                    qtyOfIdenticalItems += current.Quantity;
+                    if (current.ContentsDescription != "<<__ End of input __>>")
+                    {
+                        resultGroups.Add(
+                            new PackingListItem(
+                                current.Pallet,
+                                current.Box,
+                                current.ContentsDescription,
+                                current.Quantity)
+                                {
+                                    Count = current.Box, To = current.Box
+                                });
+                        qtyOfIdenticalItems += current.Quantity;
+                    }
+
                     continue;
                 }
 

--- a/src/Facade/ResourceBuilders/ConsignmentShipfileResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/ConsignmentShipfileResourceBuilder.cs
@@ -6,7 +6,6 @@
 
     using Linn.Common.Facade;
     using Linn.Common.Resources;
-    using Linn.Stores.Domain.LinnApps;
     using Linn.Stores.Domain.LinnApps.ConsignmentShipfiles;
     using Linn.Stores.Resources;
 

--- a/src/Facade/Services/ConsignmentShipfileFacadeService.cs
+++ b/src/Facade/Services/ConsignmentShipfileFacadeService.cs
@@ -32,15 +32,13 @@
             return new SuccessResult<IEnumerable<ConsignmentShipfile>>(this.repository.FindAll());
         }
 
-        public IResult<IEnumerable<ConsignmentShipfile>> SendEmails(
-           ConsignmentShipfilesSendEmailsRequestResource toSend)
+        public IResult<ConsignmentShipfile> SendEmails(ConsignmentShipfileSendEmailsRequestResource toSend)
         {
             var result = this.domainService.SendEmails(
-                toSend.Shipfiles.Select(
-                    s => new ConsignmentShipfile
+                 new ConsignmentShipfile
                              {
-                                 Id = s.Id, ConsignmentId = s.ConsignmentId
-                             }), 
+                                 Id = toSend.Shipfile.Id, ConsignmentId = toSend.Shipfile.ConsignmentId
+                             }, 
                 toSend.Test,
                 toSend.TestEmailAddress);
 
@@ -49,7 +47,7 @@
                 this.transactionManager.Commit();
             }
 
-            return new SuccessResult<IEnumerable<ConsignmentShipfile>>(result);
+            return new SuccessResult<ConsignmentShipfile>(result);
         }
 
         public IResult<ConsignmentShipfile> DeleteShipfile(int id)

--- a/src/Facade/Services/IConsignmentShipfileFacadeService.cs
+++ b/src/Facade/Services/IConsignmentShipfileFacadeService.cs
@@ -3,7 +3,6 @@
     using System.Collections.Generic;
 
     using Linn.Common.Facade;
-    using Linn.Stores.Domain.LinnApps;
     using Linn.Stores.Domain.LinnApps.ConsignmentShipfiles;
     using Linn.Stores.Resources;
 
@@ -11,7 +10,7 @@
     {
         IResult<IEnumerable<ConsignmentShipfile>> GetShipfiles();
 
-        IResult<IEnumerable<ConsignmentShipfile>> SendEmails(ConsignmentShipfilesSendEmailsRequestResource toSend);
+        IResult<ConsignmentShipfile> SendEmails(ConsignmentShipfileSendEmailsRequestResource toSend);
 
         IResult<ConsignmentShipfile> DeleteShipfile(int id);
     }

--- a/src/IoC/ServiceModule.cs
+++ b/src/IoC/ServiceModule.cs
@@ -34,6 +34,8 @@
     using Linn.Stores.Resources.StockLocators;
     using Linn.Stores.Resources.Tqms;
 
+    using PuppeteerSharp;
+
     public class ServiceModule : Module
     {
         protected override void Load(ContainerBuilder builder)
@@ -165,6 +167,17 @@
             builder.RegisterType<ProductionTriggerLevelsProxy>().As<IProductionTriggerLevelsService>().WithParameter(
                 "rootUri",
                 ConfigurationManager.Configuration["PROXY_ROOT"]);
+
+            builder.Register(c => Puppeteer.LaunchAsync(new LaunchOptions
+                                                            {
+                                                                Args = new[]
+                                                                           {
+                                                                               "--no-sandbox"
+                                                                           },
+                                                                Headless = true
+                                                            }).Result)
+                .As<Browser>()
+                .SingleInstance();
         }
     }
 }

--- a/src/Proxy/ConsignmentShipfileDataProxy.cs
+++ b/src/Proxy/ConsignmentShipfileDataProxy.cs
@@ -106,7 +106,11 @@
                 int.TryParse(data[2].ToString(), out var box);
                 int.TryParse(data[1].ToString(), out var pallet);
                 decimal.TryParse(data[4].ToString(), out var qty);
-                var item = new PackingListItem(pallet, box, data[3].ToString(), qty);
+                var item = new PackingListItem(
+                    pallet == 0 ? (int?)null : pallet,
+                    box == 0 ? (int?)null : box,
+                    data[3].ToString(),
+                    qty);
                 result.Add(item);
             }
 

--- a/src/Proxy/EmailService.cs
+++ b/src/Proxy/EmailService.cs
@@ -61,6 +61,7 @@
                 var a = new MimePart("application", "pdf")
                                         {
                                             Content = content,
+                                            FileName = "Shipfile.pdf"
                                         };
 
                 var multipart = new Multipart("mixed") { emailBody, a };

--- a/src/Proxy/PdfService.cs
+++ b/src/Proxy/PdfService.cs
@@ -26,7 +26,7 @@
 
             var pdfStream = page.PdfStreamAsync(pdfOptions).Result;
 
-            await this.browser.CloseAsync();
+            await page.CloseAsync();
 
             return pdfStream;
         }

--- a/src/Proxy/PdfService.cs
+++ b/src/Proxy/PdfService.cs
@@ -9,18 +9,16 @@
 
     public class PdfService : IPdfService
     {
+        private readonly Browser browser;
+
+        public PdfService(Browser browser)
+        {
+            this.browser = browser;
+        }
+
         public async Task<Stream> ConvertHtmlToPdf(string html, bool landscape)
         {
-            var browser =
-                await Puppeteer.LaunchAsync(new LaunchOptions
-                                                {
-                                                    Args = new[]
-                                                               {
-                                                                   "--no-sandbox"
-                                                               }, 
-                                                    Headless = true
-                                                });
-            var page = await browser.NewPageAsync();
+            var page = await this.browser.NewPageAsync();
 
             await page.SetContentAsync(html);
 
@@ -28,7 +26,7 @@
 
             var pdfStream = page.PdfStreamAsync(pdfOptions).Result;
 
-            await browser.CloseAsync();
+            await this.browser.CloseAsync();
 
             return pdfStream;
         }

--- a/src/Resources/ConsignmentShipfileSendEmailsRequestResource.cs
+++ b/src/Resources/ConsignmentShipfileSendEmailsRequestResource.cs
@@ -2,9 +2,9 @@
 {
     using System.Collections.Generic;
 
-    public class ConsignmentShipfilesSendEmailsRequestResource
+    public class ConsignmentShipfileSendEmailsRequestResource
     {
-        public IEnumerable<ConsignmentShipfileResource> Shipfiles { get; set; }
+        public ConsignmentShipfileResource Shipfile { get; set; }
 
         public bool Test { get; set; }
 

--- a/src/Service.Host/Startup.cs
+++ b/src/Service.Host/Startup.cs
@@ -40,7 +40,7 @@ namespace Linn.Stores.Service.Host
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApplicationLifetime applicationLifetime)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseCors(builder => builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
 
@@ -64,7 +64,6 @@ namespace Linn.Stores.Service.Host
                     }));
             app.Use((context, next) => context.ChallengeAsync(OpenIdConnectDefaults.AuthenticationScheme));
             app.PreparePuppeteerAsync(env).GetAwaiter().GetResult();
-            applicationLifetime.ApplicationStopping.Register(() => app.ApplicationServices.GetService<Browser>().CloseAsync());
         }
     }
 }

--- a/src/Service.Host/Startup.cs
+++ b/src/Service.Host/Startup.cs
@@ -17,6 +17,8 @@ namespace Linn.Stores.Service.Host
     using Nancy;
     using Nancy.Owin;
 
+    using PuppeteerSharp;
+
     public class Startup
     {
         // This method gets called by the runtime. Use this method to add services to the container.
@@ -38,7 +40,7 @@ namespace Linn.Stores.Service.Host
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApplicationLifetime applicationLifetime)
         {
             app.UseCors(builder => builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
 
@@ -60,9 +62,10 @@ namespace Linn.Stores.Service.Host
                     {
                         config.PassThroughWhenStatusCodesAre(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
                     }));
-
+            app.ApplicationServices.GetService<Browser>();
             app.Use((context, next) => context.ChallengeAsync(OpenIdConnectDefaults.AuthenticationScheme));
             app.PreparePuppeteerAsync(env).GetAwaiter().GetResult();
+            applicationLifetime.ApplicationStopping.Register(() => app.ApplicationServices.GetService<Browser>().CloseAsync());
         }
     }
 }

--- a/src/Service.Host/Startup.cs
+++ b/src/Service.Host/Startup.cs
@@ -62,7 +62,6 @@ namespace Linn.Stores.Service.Host
                     {
                         config.PassThroughWhenStatusCodesAre(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
                     }));
-            app.ApplicationServices.GetService<Browser>();
             app.Use((context, next) => context.ChallengeAsync(OpenIdConnectDefaults.AuthenticationScheme));
             app.PreparePuppeteerAsync(env).GetAwaiter().GetResult();
             applicationLifetime.ApplicationStopping.Register(() => app.ApplicationServices.GetService<Browser>().CloseAsync());

--- a/src/Service.Host/client/src/components/ConsignmentShipfiles.js
+++ b/src/Service.Host/client/src/components/ConsignmentShipfiles.js
@@ -17,7 +17,7 @@ export default function ConsignmentShipfiles({
     deleteShipfile,
     deleteLoading
 }) {
-    const [selectedRows, setSelectedRows] = useState([227165]);
+    const [selectedRows, setSelectedRows] = useState([]);
     const [rows, setRows] = useState([]);
     const [testEmailAddress, setTestEmailAddress] = useState();
 
@@ -78,9 +78,9 @@ export default function ConsignmentShipfiles({
                                 variant="contained"
                                 onClick={() => {
                                     clearErrors();
-                                    sendEmails({
-                                        shipfiles: selectedRows
-                                    });
+                                    selectedRows.forEach(r =>
+                                        sendEmails({ shipfile: r, test: true, testEmailAddress })
+                                    );
                                 }}
                             >
                                 Send Selected
@@ -129,11 +129,9 @@ export default function ConsignmentShipfiles({
                                 disabled={!testEmailAddress}
                                 onClick={() => {
                                     clearErrors();
-                                    sendEmails({
-                                        shipfiles: selectedRows,
-                                        test: true,
-                                        testEmailAddress
-                                    });
+                                    selectedRows.forEach(r =>
+                                        sendEmails({ shipfile: r, test: true, testEmailAddress })
+                                    );
                                 }}
                             >
                                 Test Selected

--- a/src/Service.Host/client/src/components/ConsignmentShipfiles.js
+++ b/src/Service.Host/client/src/components/ConsignmentShipfiles.js
@@ -10,10 +10,9 @@ export default function ConsignmentShipfiles({
     consignmentShipfiles,
     consignmentShipfilesLoading,
     sendEmails,
-    processedShipfiles,
+    processedShipfile,
     itemError,
     clearErrors,
-    sendEmailsLoading,
     deleteShipfile,
     deleteLoading
 }) {
@@ -31,14 +30,14 @@ export default function ConsignmentShipfiles({
     }, [consignmentShipfiles]);
 
     useEffect(() => {
-        if (processedShipfiles?.length) {
-            processedShipfiles.forEach(processed =>
-                setRows(r =>
-                    r.map(row => (row.id === processed.id ? { ...processed, id: row.id } : row))
+        if (processedShipfile) {
+            setRows(r =>
+                r.map(row =>
+                    row.id === processedShipfile.id ? { ...processedShipfile, id: row.id } : row
                 )
             );
         }
-    }, [processedShipfiles]);
+    }, [processedShipfile]);
 
     const columns = [
         { field: 'id', headerName: 'Id', width: 0, hide: true },
@@ -57,7 +56,7 @@ export default function ConsignmentShipfiles({
                 <Grid item xs={12}>
                     <Title text="Send Shipfile Emails" />
                 </Grid>
-                {(sendEmailsLoading || deleteLoading) && !itemError ? (
+                {deleteLoading && !itemError ? (
                     <Grid item xs={12}>
                         <Loading />
                     </Grid>
@@ -129,9 +128,14 @@ export default function ConsignmentShipfiles({
                                 disabled={!testEmailAddress}
                                 onClick={() => {
                                     clearErrors();
-                                    selectedRows.forEach(r =>
-                                        sendEmails({ shipfile: r, test: true, testEmailAddress })
-                                    );
+                                    selectedRows.forEach(r => {
+                                        setRows(shipfiles =>
+                                            shipfiles.map(s =>
+                                                s.id === r.id ? { ...r, status: 'Processing' } : s
+                                            )
+                                        );
+                                        sendEmails({ shipfile: r, test: true, testEmailAddress });
+                                    });
                                 }}
                             >
                                 Test Selected
@@ -146,7 +150,7 @@ export default function ConsignmentShipfiles({
 
 ConsignmentShipfiles.propTypes = {
     consignmentShipfiles: PropTypes.arrayOf(PropTypes.shape({})),
-    processedShipfiles: PropTypes.arrayOf(PropTypes.shape({})),
+    processedShipfile: PropTypes.shape({ id: PropTypes.number }),
     consignmentShipfilesLoading: PropTypes.bool,
     sendEmails: PropTypes.func.isRequired,
     deleteShipfile: PropTypes.func.isRequired,
@@ -156,16 +160,14 @@ ConsignmentShipfiles.propTypes = {
         statusText: PropTypes.string,
         details: PropTypes.shape({ errors: PropTypes.arrayOf(PropTypes.string) })
     }),
-    sendEmailsLoading: PropTypes.bool,
     whatToWandReport: PropTypes.shape({})
 };
 
 ConsignmentShipfiles.defaultProps = {
     consignmentShipfiles: [],
-    processedShipfiles: [],
+    processedShipfile: null,
     consignmentShipfilesLoading: true,
     itemError: null,
-    sendEmailsLoading: false,
     whatToWandReport: null,
     deleteLoading: false
 };

--- a/src/Service.Host/client/src/components/ConsignmentShipfiles.js
+++ b/src/Service.Host/client/src/components/ConsignmentShipfiles.js
@@ -77,9 +77,14 @@ export default function ConsignmentShipfiles({
                                 variant="contained"
                                 onClick={() => {
                                     clearErrors();
-                                    selectedRows.forEach(r =>
-                                        sendEmails({ shipfile: r, test: true, testEmailAddress })
-                                    );
+                                    selectedRows.forEach(r => {
+                                        setRows(shipfiles =>
+                                            shipfiles.map(s =>
+                                                s.id === r.id ? { ...r, status: 'Processing' } : s
+                                            )
+                                        );
+                                        sendEmails({ shipfile: r });
+                                    });
                                 }}
                             >
                                 Send Selected

--- a/src/Service.Host/client/src/containers/ConsignmentShipfiles.js
+++ b/src/Service.Host/client/src/containers/ConsignmentShipfiles.js
@@ -12,7 +12,7 @@ import shipfilesSendEmailsActions from '../actions/shipfilesSendEmailsActions';
 const mapStateToProps = state => ({
     consignmentShipfiles: consignmentShipfilesSelectors.getItems(state),
     consignmentShipfilesLoading: consignmentShipfilesSelectors.getLoading(state),
-    processedShipfiles: shipfilesSendEmailsSelectors.getData(state),
+    processedShipfile: shipfilesSendEmailsSelectors.getData(state),
     sendEmailsLoading: shipfilesSendEmailsSelectors.getWorking(state),
     itemError: getItemError(state, processTypes.shipfilesSendEmails.item),
     deleteLoading: consignmentShipfileSelectors.getLoading(state)

--- a/src/Service/Modules/WandModule.cs
+++ b/src/Service/Modules/WandModule.cs
@@ -60,7 +60,7 @@
 
         private object SendEmails()
         {
-            var resource = this.Bind<ConsignmentShipfilesSendEmailsRequestResource>();
+            var resource = this.Bind<ConsignmentShipfileSendEmailsRequestResource>();
             return this.Negotiate.WithModel(this.shipfileService.SendEmails(resource));
         }
 

--- a/tests/Integration/Service.Tests/WandModuleSpecs/WhenSendingShipfileEmails.cs
+++ b/tests/Integration/Service.Tests/WandModuleSpecs/WhenSendingShipfileEmails.cs
@@ -1,12 +1,8 @@
 ﻿namespace Linn.Stores.Service.Tests.WandModuleSpecs
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
     using FluentAssertions;
 
     using Linn.Common.Facade;
-    using Linn.Stores.Domain.LinnApps;
     using Linn.Stores.Domain.LinnApps.ConsignmentShipfiles;
     using Linn.Stores.Resources;
 
@@ -21,7 +17,7 @@
     {
         private ConsignmentShipfileSendEmailsRequestResource resource;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         [SetUp]
         public void SetUp()
@@ -29,26 +25,20 @@
             this.resource = new ConsignmentShipfileSendEmailsRequestResource
                                 {
                                     Test = false,
-                                    Shipfiles = new List<ConsignmentShipfileResource>
-                                                    {
-                                                        new ConsignmentShipfileResource
+                                    Shipfile = new ConsignmentShipfileResource
                                                             {
                                                                 ConsignmentId = 1,
                                                             }
-                                                    }
                                 };
 
-            this.result = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile
+            this.result = new ConsignmentShipfile
                                       {
                                           ConsignmentId = 1,
                                           Consignment = new Consignment()
-                                      }
-                              };
+                                      };
 
             this.ShipfileService.SendEmails(Arg.Any<ConsignmentShipfileSendEmailsRequestResource>())
-                .Returns(new SuccessResult<IEnumerable<ConsignmentShipfile>>(this.result));
+                .Returns(new SuccessResult<ConsignmentShipfile>(this.result));
 
             this.Response = this.Browser.Post(
                 $"/logistics/shipfiles/send-emails",
@@ -74,8 +64,8 @@
         [Test]
         public void ShouldReturnResult()
         {
-            var res = this.Response.Body.DeserializeJson<IEnumerable<ConsignmentShipfile>>();
-            res.First().ConsignmentId.Should().Be(1);
+            var res = this.Response.Body.DeserializeJson<ConsignmentShipfile>();
+            res.ConsignmentId.Should().Be(1);
         }
     }
 }

--- a/tests/Integration/Service.Tests/WandModuleSpecs/WhenSendingShipfileEmails.cs
+++ b/tests/Integration/Service.Tests/WandModuleSpecs/WhenSendingShipfileEmails.cs
@@ -19,14 +19,14 @@
 
     public class WhenSendingShipfileEmails : ContextBase
     {
-        private ConsignmentShipfilesSendEmailsRequestResource resource;
+        private ConsignmentShipfileSendEmailsRequestResource resource;
 
         private IEnumerable<ConsignmentShipfile> result;
 
         [SetUp]
         public void SetUp()
         {
-            this.resource = new ConsignmentShipfilesSendEmailsRequestResource
+            this.resource = new ConsignmentShipfileSendEmailsRequestResource
                                 {
                                     Test = false,
                                     Shipfiles = new List<ConsignmentShipfileResource>
@@ -47,7 +47,7 @@
                                       }
                               };
 
-            this.ShipfileService.SendEmails(Arg.Any<ConsignmentShipfilesSendEmailsRequestResource>())
+            this.ShipfileService.SendEmails(Arg.Any<ConsignmentShipfileSendEmailsRequestResource>())
                 .Returns(new SuccessResult<IEnumerable<ConsignmentShipfile>>(this.result));
 
             this.Response = this.Browser.Post(
@@ -68,7 +68,7 @@
         [Test]
         public void ShouldCallFacadeService()
         {
-            this.ShipfileService.Received().SendEmails(Arg.Any<ConsignmentShipfilesSendEmailsRequestResource>());
+            this.ShipfileService.Received().SendEmails(Arg.Any<ConsignmentShipfileSendEmailsRequestResource>());
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailAndEmailAlreadySent.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailAndEmailAlreadySent.cs
@@ -1,8 +1,6 @@
 ﻿namespace Linn.Stores.Domain.LinnApps.Tests.ConsignmentShipfileServiceTests
 {
-    using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
 
     using FluentAssertions;
 
@@ -14,20 +12,17 @@
 
     public class WhenSendingAnEmailAndEmailAlreadySent : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
        [SetUp]
         public void SetUp()
         {
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile
+            this.toSend = new ConsignmentShipfile
                                       {
                                           Id = 1
-                                      }
-                              };
+                                      };
 
             this.ShipfileRepository.FindById(1).Returns(
                 new ConsignmentShipfile { ShipfileSent = "Y", Message = ShipfileStatusMessages.EmailSent });
@@ -53,7 +48,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailAlreadySent);
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailAlreadySent);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailToAnIndividual.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailToAnIndividual.cs
@@ -14,9 +14,9 @@
 
     public class WhenSendingAnEmailToAnIndividual : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -42,10 +42,7 @@
                                         Id = 1,
                                         Consignment = consignment
                                     };
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1, ConsignmentId = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1, ConsignmentId = 1 };
 
             this.PackingListService.BuildPackingList(Arg.Any<IEnumerable<PackingListItem>>())
                 .ReturnsForAnyArgs(new List<PackingListItem> { new PackingListItem(1, 1, "desc", 1m) });
@@ -91,8 +88,8 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailSent);
-            this.result.First().ShipfileSent.Should().Be("Y");
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailSent);
+            this.result.ShipfileSent.Should().Be("Y");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailAndNoOutletAddressOrAccountAddress.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailAndNoOutletAddressOrAccountAddress.cs
@@ -16,9 +16,9 @@
 
     public class WhenSendingEmailAndNoOutletAddressOrAccountAddress : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -63,10 +63,7 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -107,7 +104,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.NoContactDetails);
+            this.result.Message.Should().Be(ShipfileStatusMessages.NoContactDetails);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailAndNoOutletEmailAddressButOutletIsOnlyOneForAccountWhichHasEmailAddress.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailAndNoOutletEmailAddressButOutletIsOnlyOneForAccountWhichHasEmailAddress.cs
@@ -16,9 +16,9 @@
 
     public class WhenSendingEmailAndNoOutletEmailAddressButOutletIsOnlyOneForAccountWhichHasEmailAddress : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -64,10 +64,7 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -110,7 +107,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailSent);
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailSent);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnIndividualAndContactDetailsMissing.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnIndividualAndContactDetailsMissing.cs
@@ -14,9 +14,9 @@
 
     public class WhenSendingEmailToAnIndividualAndContactDetailsMissing : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData; 
 
@@ -36,13 +36,10 @@
                                                                   }
                                                       }
                                 };
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile
+            this.toSend = new ConsignmentShipfile
                                       {
                                           Id = 1,
-                                      }
-                              };
+                                      };
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -67,7 +64,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.NoContactDetails);
+            this.result.Message.Should().Be(ShipfileStatusMessages.NoContactDetails);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnOrg.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnOrg.cs
@@ -16,9 +16,9 @@
 
     public class WhenSendingEmailToAnOrg : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -69,10 +69,8 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
+                             
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -124,8 +122,8 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailSent);
-            this.result.First().ShipfileSent.Should().Be("Y");
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailSent);
+            this.result.ShipfileSent.Should().Be("Y");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnOrg.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnOrg.cs
@@ -70,8 +70,7 @@
             };
 
             this.toSend = new ConsignmentShipfile { Id = 1 };
-                             
-
+            
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
             this.PackingListService.BuildPackingList(Arg.Any<IEnumerable<PackingListItem>>())

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailsToAnOrgAndContactDetailsMissingForAnOutlet.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailsToAnOrgAndContactDetailsMissingForAnOutlet.cs
@@ -16,9 +16,9 @@
 
     public class WhenSendingEmailsToAnOrgAndContactDetailsMissingForAnOutlet : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -72,10 +72,7 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -110,7 +107,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.NoContactDetailsForAnOutlet);
+            this.result.Message.Should().Be(ShipfileStatusMessages.NoContactDetailsForAnOutlet);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingToAnOrgWithMultipleOutletsWithTheSameEmailAddress.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingToAnOrgWithMultipleOutletsWithTheSameEmailAddress.cs
@@ -70,8 +70,7 @@
             };
 
             this.toSend = new ConsignmentShipfile { Id = 1 };
-                             
-
+            
             this.PackingListService.BuildPackingList(Arg.Any<IEnumerable<PackingListItem>>())
                 .ReturnsForAnyArgs(new List<PackingListItem> { new PackingListItem(1, 1, "desc", 1m) });
 

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingToAnOrgWithMultipleOutletsWithTheSameEmailAddress.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingToAnOrgWithMultipleOutletsWithTheSameEmailAddress.cs
@@ -16,9 +16,9 @@
 
     public class WhenSendingEmailToAnOrgWithMultipleOutletsWithTheSameEmailAddress : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -69,10 +69,8 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
+                             
 
             this.PackingListService.BuildPackingList(Arg.Any<IEnumerable<PackingListItem>>())
                 .ReturnsForAnyArgs(new List<PackingListItem> { new PackingListItem(1, 1, "desc", 1m) });
@@ -124,8 +122,8 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailSent);
-            this.result.First().ShipfileSent.Should().Be("Y");
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailSent);
+            this.result.ShipfileSent.Should().Be("Y");
         }
     }
 }


### PR DESCRIPTION
- splits the workload across several requests as opposed to waiting for them all to complete in one request. 
- seems to speed it up since requests can be processed in parallel
- I also changed it so that the chrome instance is launched  during Dependency Injection as a singleton as opposed to in the PdfService for every request. I put this in the IoC ServiceModule although I'm not sure thats correct?
- I'm hoping .Net is smart enough not to crash the container with too much work...