### PR TITLE
consignment print css

### DIFF
--- a/src/Service.Host/client/src/components/Root.js
+++ b/src/Service.Host/client/src/components/Root.js
@@ -54,7 +54,7 @@ import DebitNotes from '../containers/purchasing/DebitNotes';
 
 const Root = ({ store }) => (
     <div>
-        <div style={{ paddingTop: '40px' }}>
+        <div className="padding-top-when-not-printing">
             <Provider store={store}>
                 <OidcProvider store={store} userManager={userManager}>
                     <MuiPickersUtilsProvider utils={MomentUtils}>

--- a/src/Service.Host/client/src/components/consignments/Consignment.js
+++ b/src/Service.Host/client/src/components/consignments/Consignment.js
@@ -390,332 +390,344 @@ function Consignment({
     };
 
     return (
-        <Page requestErrors={requestErrors} showRequestErrors width="xl">
-            <Grid container spacing={3}>
-                <Grid item xs={2}>
-                    <Typography variant="h6" className="hide-when-printing">
-                        Consignment
-                    </Typography>
-                </Grid>
-                <Grid item xs={7}>
-                    {state.consignment && (
-                        <Typography variant="h6" className="hide-when-printing">
-                            {state.consignment.consignmentId} {state.consignment.customerName}
-                        </Typography>
-                    )}
-                </Grid>
-                <Grid item xs={3}>
-                    <Tooltip className="hide-when-printing" title="Close Consignment">
-                        <span>
-                            <Button
-                                variant="outlined"
-                                className={classes.pullRight}
-                                onClick={closeConsignment}
-                                disabled={
-                                    !viewing() ||
-                                    !state.consignment ||
-                                    state.consignment.status === 'C'
-                                }
-                            >
-                                Close Consignment
-                            </Button>
-                        </span>
-                    </Tooltip>
-                </Grid>
-                {itemError && (
-                    <Grid item xs={12}>
-                        <ErrorCard
-                            errorMessage={itemError?.details?.errors?.[0] || itemError.statusText}
-                        />
+        <div className="pageContainer">
+            <Page requestErrors={requestErrors} showRequestErrors width="xl">
+                <Grid container spacing={3}>
+                    <Grid item xs={2} className="hide-when-printing">
+                        <Typography variant="h6">Consignment</Typography>
                     </Grid>
-                )}
-                <>
-                    <Tabs
-                        className="hide-when-printing"
-                        value={currentTab}
-                        onChange={handleTabChange}
-                        style={{ paddingBottom: '20px' }}
-                    >
-                        <Tab label="Select" />
-                        <Tab label="Details" />
-                        <Tab label="Consignment Items" />
-                        <Tab label="Documents" />
-                        <Tab label="Packing List" />
-                    </Tabs>
-                    {currentTab === 0 && (
-                        <>
-                            <Grid item xs={12}>
-                                <Dropdown
-                                    label="Select open consignment"
-                                    propertyName="consignmentSelect"
-                                    items={openConsignments}
-                                    onChange={handleSelectConsignment}
-                                    optionsLoading={optionsLoading}
-                                />
-                            </Grid>
-                            <Grid item xs={12}>
-                                <InputField
-                                    label="Select Consignment By Id"
-                                    placeholder="Consignment Id"
-                                    propertyName="consignmentIdSelect"
-                                    value={consignmentIdSelect}
-                                    onChange={(_, val) => setConsignmentIdSelect(val)}
-                                />
+                    <Grid item xs={7} className="hide-when-printing">
+                        {state.consignment && (
+                            <Typography variant="h6">
+                                {state.consignment.consignmentId} {state.consignment.customerName}
+                            </Typography>
+                        )}
+                    </Grid>
+                    <Grid item xs={3} className="hide-when-printing">
+                        <Tooltip title="Close Consignment">
+                            <span>
                                 <Button
-                                    style={{ marginTop: '10px' }}
                                     variant="outlined"
-                                    color="primary"
-                                    onClick={() =>
-                                        handleSelectConsignment(null, consignmentIdSelect)
+                                    className={classes.pullRight}
+                                    onClick={closeConsignment}
+                                    disabled={
+                                        !viewing() ||
+                                        !state.consignment ||
+                                        state.consignment.status === 'C'
                                     }
                                 >
-                                    Show Consignment
+                                    Close Consignment
                                 </Button>
-                            </Grid>
-                        </>
+                            </span>
+                        </Tooltip>
+                    </Grid>
+                    {itemError && (
+                        <Grid item xs={12}>
+                            <ErrorCard
+                                errorMessage={
+                                    itemError?.details?.errors?.[0] || itemError.statusText
+                                }
+                            />
+                        </Grid>
                     )}
-                    {currentTab !== 0 && (loading || !state.consignment) ? (
-                        <Loading />
-                    ) : (
-                        <>
-                            {currentTab === 1 && (
-                                <DetailsTab
-                                    consignment={state.consignment}
-                                    hub={hub}
-                                    hubs={hubs}
-                                    updateField={updateField}
-                                    viewMode={viewMode()}
-                                    editStatus={editStatus}
-                                    hubsLoading={hubsLoading}
-                                    carrier={carrier}
-                                    carriers={carriers}
-                                    carriersLoading={carriersLoading}
-                                    shippingTerm={shippingTerm}
-                                    shippingTerms={shippingTerms}
-                                    shippingTermsLoading={shippingTermsLoading}
-                                />
-                            )}
-                            {currentTab === 2 && (
-                                <ItemsTab
-                                    editableItems={editableItems}
-                                    editablePallets={editablePallets}
-                                    dispatch={dispatch}
-                                    setSaveDisabled={setSaveDisabled}
-                                    cartonTypes={cartonTypes}
-                                    setEditStatus={setEditStatus}
-                                    viewing={viewing()}
-                                />
-                            )}
-                            {currentTab === 3 && (
-                                <InvoicesTab
-                                    invoices={state.consignment.invoices}
-                                    exportBooks={state.consignment.exportBooks}
-                                    printDocuments={handlePrintDocuments}
-                                    printDocumentsWorking={printDocumentsWorking}
-                                    printDocumentsResult={printDocumentsResult}
-                                />
-                            )}
-                            {currentTab === 4 && (
-                                <PackingListTab
-                                    consignmentPackingList={consignmentPackingList}
-                                    consignmentPackingListLoading={consignmentPackingListLoading}
-                                />
-                            )}
-                        </>
-                    )}
-                </>
-                <Grid item xs={12} style={{ marginTop: '20px' }}>
-                    {currentTab === 2 && (
-                        <>
-                            <Button
-                                variant="outlined"
-                                color="primary"
-                                onClick={addPallet}
-                                disabled={viewing()}
-                            >
-                                Add Pallet
-                            </Button>
-                            <Button
-                                variant="outlined"
-                                color="primary"
-                                onClick={addCarton}
-                                disabled={viewing()}
-                            >
-                                Add Carton
-                            </Button>
-                            <Button
-                                variant="outlined"
-                                color="primary"
-                                onClick={addItem}
-                                disabled={viewing()}
-                            >
-                                Add Item
-                            </Button>
-                            <Button
-                                variant="outlined"
-                                color="primary"
-                                onClick={showCartonLabelForm}
-                            >
-                                Carton Label
-                            </Button>
-                            <Button
-                                variant="outlined"
-                                color="primary"
-                                onClick={showPalletLabelForm}
-                            >
-                                Pallet Label
-                            </Button>
-                        </>
-                    )}
-                    {editStatus === 'view' ? (
-                        <Button
-                            variant="outlined"
-                            color="primary"
-                            className={`${classes.pullRight} hide-when-printing`}
-                            onClick={startEdit}
-                            disabled={!state.consignment || state.consignment.status === 'C'}
+                    <>
+                        <Tabs
+                            className="hide-when-printing"
+                            value={currentTab}
+                            onChange={handleTabChange}
+                            style={{ paddingBottom: '20px' }}
                         >
-                            Edit
-                        </Button>
-                    ) : (
-                        <SaveBackCancelButtons
-                            saveClick={doSave}
-                            backClick={() => {}}
-                            cancelClick={doCancel}
-                            saveDisabled={saveDisabled}
-                        />
-                    )}
+                            <Tab label="Select" />
+                            <Tab label="Details" />
+                            <Tab label="Consignment Items" />
+                            <Tab label="Documents" />
+                            <Tab label="Packing List" />
+                        </Tabs>
+                        {currentTab === 0 && (
+                            <>
+                                <Grid item xs={12}>
+                                    <Dropdown
+                                        label="Select open consignment"
+                                        propertyName="consignmentSelect"
+                                        items={openConsignments}
+                                        onChange={handleSelectConsignment}
+                                        optionsLoading={optionsLoading}
+                                    />
+                                </Grid>
+                                <Grid item xs={12}>
+                                    <InputField
+                                        label="Select Consignment By Id"
+                                        placeholder="Consignment Id"
+                                        propertyName="consignmentIdSelect"
+                                        value={consignmentIdSelect}
+                                        onChange={(_, val) => setConsignmentIdSelect(val)}
+                                    />
+                                    <Button
+                                        style={{ marginTop: '10px' }}
+                                        variant="outlined"
+                                        color="primary"
+                                        onClick={() =>
+                                            handleSelectConsignment(null, consignmentIdSelect)
+                                        }
+                                    >
+                                        Show Consignment
+                                    </Button>
+                                </Grid>
+                            </>
+                        )}
+                        {currentTab !== 0 && (loading || !state.consignment) ? (
+                            <Loading />
+                        ) : (
+                            <>
+                                {currentTab === 1 && (
+                                    <DetailsTab
+                                        consignment={state.consignment}
+                                        hub={hub}
+                                        hubs={hubs}
+                                        updateField={updateField}
+                                        viewMode={viewMode()}
+                                        editStatus={editStatus}
+                                        hubsLoading={hubsLoading}
+                                        carrier={carrier}
+                                        carriers={carriers}
+                                        carriersLoading={carriersLoading}
+                                        shippingTerm={shippingTerm}
+                                        shippingTerms={shippingTerms}
+                                        shippingTermsLoading={shippingTermsLoading}
+                                    />
+                                )}
+                                {currentTab === 2 && (
+                                    <ItemsTab
+                                        editableItems={editableItems}
+                                        editablePallets={editablePallets}
+                                        dispatch={dispatch}
+                                        setSaveDisabled={setSaveDisabled}
+                                        cartonTypes={cartonTypes}
+                                        setEditStatus={setEditStatus}
+                                        viewing={viewing()}
+                                    />
+                                )}
+                                {currentTab === 3 && (
+                                    <InvoicesTab
+                                        invoices={state.consignment.invoices}
+                                        exportBooks={state.consignment.exportBooks}
+                                        printDocuments={handlePrintDocuments}
+                                        printDocumentsWorking={printDocumentsWorking}
+                                        printDocumentsResult={printDocumentsResult}
+                                    />
+                                )}
+                                {currentTab === 4 && (
+                                    <PackingListTab
+                                        consignmentPackingList={consignmentPackingList}
+                                        consignmentPackingListLoading={
+                                            consignmentPackingListLoading
+                                        }
+                                    />
+                                )}
+                            </>
+                        )}
+                    </>
+                    <Grid item xs={12} style={{ marginTop: '20px' }}>
+                        {currentTab === 2 && (
+                            <>
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    onClick={addPallet}
+                                    disabled={viewing()}
+                                >
+                                    Add Pallet
+                                </Button>
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    onClick={addCarton}
+                                    disabled={viewing()}
+                                >
+                                    Add Carton
+                                </Button>
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    onClick={addItem}
+                                    disabled={viewing()}
+                                >
+                                    Add Item
+                                </Button>
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    onClick={showCartonLabelForm}
+                                >
+                                    Carton Label
+                                </Button>
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    onClick={showPalletLabelForm}
+                                >
+                                    Pallet Label
+                                </Button>
+                            </>
+                        )}
+                        {editStatus === 'view' ? (
+                            <Button
+                                variant="outlined"
+                                color="primary"
+                                className={`${classes.pullRight} hide-when-printing`}
+                                onClick={startEdit}
+                                disabled={!state.consignment || state.consignment.status === 'C'}
+                            >
+                                Edit
+                            </Button>
+                        ) : (
+                            <SaveBackCancelButtons
+                                saveClick={doSave}
+                                backClick={() => {}}
+                                cancelClick={doCancel}
+                                saveDisabled={saveDisabled}
+                            />
+                        )}
+                    </Grid>
                 </Grid>
-            </Grid>
-            <Dialog
-                open={showCartonLabel}
-                onClose={() => setShowCartonLabel(false)}
-                aria-labelledby="alert-dialog-title"
-                aria-describedby="alert-dialog-description"
-                fullWidth
-                maxWidth="sm"
-            >
-                <DialogTitle id="alert-dialog-title">Print Carton Label</DialogTitle>
-                <DialogContent>
-                    <>
-                        <Grid container>
-                            <Grid item xs={6}>
-                                <InputField
-                                    label="First Carton"
-                                    placeholder="First Carton"
-                                    propertyName="firstItem"
-                                    value={cartonLabelOptions.firstItem}
-                                    onChange={updateCartonLabelOptions}
-                                    maxLength={3}
-                                />
-                                <InputField
-                                    label="Last Carton"
-                                    placeholder="Last Carton"
-                                    propertyName="lastItem"
-                                    value={cartonLabelOptions.lastItem}
-                                    onChange={updateCartonLabelOptions}
-                                    maxLength={3}
-                                />
-                                <InputField
-                                    label="Copies"
-                                    placeholder="Copies To Print"
-                                    propertyName="numberOfCopies"
-                                    value={cartonLabelOptions.numberOfCopies}
-                                    onChange={updateCartonLabelOptions}
-                                    maxLength={3}
-                                />
+                <Dialog
+                    open={showCartonLabel}
+                    onClose={() => setShowCartonLabel(false)}
+                    aria-labelledby="alert-dialog-title"
+                    aria-describedby="alert-dialog-description"
+                    fullWidth
+                    maxWidth="sm"
+                >
+                    <DialogTitle id="alert-dialog-title">Print Carton Label</DialogTitle>
+                    <DialogContent>
+                        <>
+                            <Grid container>
+                                <Grid item xs={6}>
+                                    <InputField
+                                        label="First Carton"
+                                        placeholder="First Carton"
+                                        propertyName="firstItem"
+                                        value={cartonLabelOptions.firstItem}
+                                        onChange={updateCartonLabelOptions}
+                                        maxLength={3}
+                                    />
+                                    <InputField
+                                        label="Last Carton"
+                                        placeholder="Last Carton"
+                                        propertyName="lastItem"
+                                        value={cartonLabelOptions.lastItem}
+                                        onChange={updateCartonLabelOptions}
+                                        maxLength={3}
+                                    />
+                                    <InputField
+                                        label="Copies"
+                                        placeholder="Copies To Print"
+                                        propertyName="numberOfCopies"
+                                        value={cartonLabelOptions.numberOfCopies}
+                                        onChange={updateCartonLabelOptions}
+                                        maxLength={3}
+                                    />
+                                </Grid>
+                                <Grid item xs={6}>
+                                    <Button
+                                        style={{ marginTop: '30px', marginBottom: '40px' }}
+                                        onClick={doPrintCartonLabel}
+                                        variant="contained"
+                                        color="primary"
+                                    >
+                                        Print Carton Label
+                                    </Button>
+                                    {printConsignmentLabelWorking ? (
+                                        <Loading />
+                                    ) : (
+                                        <Typography variant="h6">
+                                            {printConsignmentLabelResult?.message}
+                                        </Typography>
+                                    )}
+                                </Grid>
                             </Grid>
-                            <Grid item xs={6}>
-                                <Button
-                                    style={{ marginTop: '30px', marginBottom: '40px' }}
-                                    onClick={doPrintCartonLabel}
-                                    variant="contained"
-                                    color="primary"
-                                >
-                                    Print Carton Label
-                                </Button>
-                                {printConsignmentLabelWorking ? (
-                                    <Loading />
-                                ) : (
-                                    <Typography variant="h6">
-                                        {printConsignmentLabelResult?.message}
-                                    </Typography>
-                                )}
+                        </>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button
+                            onClick={() => setShowCartonLabel(false)}
+                            variant="contained"
+                            autoFocus
+                        >
+                            Close
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+                <Dialog
+                    open={showPalletLabel}
+                    onClose={() => setShowPalletLabel(false)}
+                    aria-labelledby="alert-dialog-title"
+                    aria-describedby="alert-dialog-description"
+                    fullWidth
+                    maxWidth="sm"
+                >
+                    <DialogTitle id="alert-dialog-title">Print Pallet Label</DialogTitle>
+                    <DialogContent>
+                        <>
+                            <Grid container>
+                                <Grid item xs={6}>
+                                    <InputField
+                                        label="First Pallet"
+                                        placeholder="First Pallet"
+                                        propertyName="firstItem"
+                                        value={palletLabelOptions.firstItem}
+                                        onChange={updatePalletLabelOptions}
+                                        maxLength={3}
+                                    />
+                                    <InputField
+                                        label="Last Pallet"
+                                        placeholder="Last Pallet"
+                                        propertyName="lastItem"
+                                        value={palletLabelOptions.lastItem}
+                                        onChange={updatePalletLabelOptions}
+                                        maxLength={3}
+                                    />
+                                    <InputField
+                                        label="Copies"
+                                        placeholder="Copies To Print"
+                                        propertyName="numberOfCopies"
+                                        value={palletLabelOptions.numberOfCopies}
+                                        onChange={updatePalletLabelOptions}
+                                        maxLength={3}
+                                    />
+                                </Grid>
+                                <Grid item xs={6}>
+                                    <Button
+                                        style={{ marginTop: '30px', marginBottom: '40px' }}
+                                        onClick={doPrintPalletLabel}
+                                        variant="contained"
+                                        color="primary"
+                                    >
+                                        Print Pallet Label
+                                    </Button>
+                                    {printConsignmentLabelWorking ? (
+                                        <Loading />
+                                    ) : (
+                                        <Typography variant="h6">
+                                            {printConsignmentLabelResult?.message}
+                                        </Typography>
+                                    )}
+                                </Grid>
                             </Grid>
-                        </Grid>
-                    </>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={() => setShowCartonLabel(false)} variant="contained" autoFocus>
-                        Close
-                    </Button>
-                </DialogActions>
-            </Dialog>
-            <Dialog
-                open={showPalletLabel}
-                onClose={() => setShowPalletLabel(false)}
-                aria-labelledby="alert-dialog-title"
-                aria-describedby="alert-dialog-description"
-                fullWidth
-                maxWidth="sm"
-            >
-                <DialogTitle id="alert-dialog-title">Print Pallet Label</DialogTitle>
-                <DialogContent>
-                    <>
-                        <Grid container>
-                            <Grid item xs={6}>
-                                <InputField
-                                    label="First Pallet"
-                                    placeholder="First Pallet"
-                                    propertyName="firstItem"
-                                    value={palletLabelOptions.firstItem}
-                                    onChange={updatePalletLabelOptions}
-                                    maxLength={3}
-                                />
-                                <InputField
-                                    label="Last Pallet"
-                                    placeholder="Last Pallet"
-                                    propertyName="lastItem"
-                                    value={palletLabelOptions.lastItem}
-                                    onChange={updatePalletLabelOptions}
-                                    maxLength={3}
-                                />
-                                <InputField
-                                    label="Copies"
-                                    placeholder="Copies To Print"
-                                    propertyName="numberOfCopies"
-                                    value={palletLabelOptions.numberOfCopies}
-                                    onChange={updatePalletLabelOptions}
-                                    maxLength={3}
-                                />
-                            </Grid>
-                            <Grid item xs={6}>
-                                <Button
-                                    style={{ marginTop: '30px', marginBottom: '40px' }}
-                                    onClick={doPrintPalletLabel}
-                                    variant="contained"
-                                    color="primary"
-                                >
-                                    Print Pallet Label
-                                </Button>
-                                {printConsignmentLabelWorking ? (
-                                    <Loading />
-                                ) : (
-                                    <Typography variant="h6">
-                                        {printConsignmentLabelResult?.message}
-                                    </Typography>
-                                )}
-                            </Grid>
-                        </Grid>
-                    </>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={() => setShowPalletLabel(false)} variant="contained" autoFocus>
-                        Close
-                    </Button>
-                </DialogActions>
-            </Dialog>
-        </Page>
+                        </>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button
+                            onClick={() => setShowPalletLabel(false)}
+                            variant="contained"
+                            autoFocus
+                        >
+                            Close
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            </Page>
+        </div>
     );
 }
 


### PR DESCRIPTION
Not perfect, but seems mostly better?

- got rid of some blank space at top - print style: padding-top-when-not-printing, which has negative margin on print instead of constant margin 
https://github.com/linn/react-components-library/blob/master/src/styles/printStyles.css#L35

- add pageContainer print style to a div containing the consignment page, on print sets the height and width to exactly a4 size
- move style to hide on print onto grids from inner components - seems to get rid of some more empty space at top
Files changed tab looks like carnage but that's all I've done ^

![image](https://user-images.githubusercontent.com/51612225/133771271-06f5c733-33cf-4e42-bd7f-f4885a20d39a.png)


![image](https://user-images.githubusercontent.com/51612225/133771221-c6f613b2-1db0-46a4-9aa7-9f1d8819e062.png)
