### PR TITLE
Shipfiles no order contact bug fix

### DIFF
--- a/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
+++ b/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
@@ -163,7 +163,7 @@
 
                 var outlets = orders.ToList()
                     .Select(o => o.SalesOutlet)
-                    .GroupBy(elem => $"{elem.OutletNumber}-{elem.OrderContact.EmailAddress}")
+                    .GroupBy(elem => $"{elem.OutletNumber}-{elem.OrderContact?.EmailAddress}")
                     .Select(group => group.First()).ToList();
 
                 // if email address missing for one of the outlets

--- a/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
+++ b/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
@@ -50,40 +50,36 @@
             this.packingListService = packingListService;
         }
 
-        public IEnumerable<ConsignmentShipfile> SendEmails(
-            IEnumerable<ConsignmentShipfile> toSend,
+        public ConsignmentShipfile SendEmails(
+            ConsignmentShipfile toSend,
             bool test = false,
             string testEmailAddress = null)
         {
-            var withDetails = new List<ConsignmentShipfile>();
-            foreach (var shipfile in toSend)
+            var data = this.shipfileRepository.FindById(toSend.Id);
+
+            if (data.ShipfileSent == "Y")
             {
-                var data = this.shipfileRepository.FindById(shipfile.Id);
+                data.Message = ShipfileStatusMessages.EmailAlreadySent;
+                return data;
+            }
 
-                if (data.ShipfileSent == "Y")
+            var models = this.BuildEmailModels(data);
+
+            // A message implies there is some problem with generating the email
+            if (data.Message == null)
+            {
+                // potentially an email to send to each outlet in this consignment?
+                foreach (var model in models)
                 {
-                    data.Message = ShipfileStatusMessages.EmailAlreadySent;
-                    withDetails.Add(data);
-                    continue;
-                }
+                    model.Subject = test ? model.ToEmailAddress : "Shipping Details";
 
-                var models = this.BuildEmailModels(data);
-
-                // A message implies there is some problem with generating the email
-                if (data.Message == null)
-                {
-                    // potentially an email to send to each outlet in this consignment?
-                    foreach (var model in models)
-                    {
-                        model.Subject = test ? model.ToEmailAddress : "Shipping Details";
-
-                        var render = this.templateEngine.Render(
+                    var render = this.templateEngine.Render(
                             model.PdfAttachment,
                             ConfigurationManager.Configuration["SHIPFILE_TEMPLATE_PATH"]);
 
-                        var pdf = this.pdfService.ConvertHtmlToPdf(render.Result, landscape: true);
+                    var pdf = this.pdfService.ConvertHtmlToPdf(render.Result, landscape: true);
 
-                        this.emailService.SendEmail(
+                    this.emailService.SendEmail(
                             test ? testEmailAddress : model.ToEmailAddress,
                             model.ToCustomerName,
                             null,
@@ -94,32 +90,29 @@
                             model.Body,
                             pdf.Result,
                             "Shipfile");
-                    }
-
-                    if (test)
-                    {
-                        data.Message = ShipfileStatusMessages.TestEmailSent;
-                    }
-                    else
-                    {
-                        data.Message = ShipfileStatusMessages.EmailSent;
-                        data.ShipfileSent = "Y";
-                    }
                 }
 
-                withDetails.Add(new ConsignmentShipfile
+                if (test)
+                {
+                    data.Message = ShipfileStatusMessages.TestEmailSent;
+                }
+                else
+                {
+                    data.Message = ShipfileStatusMessages.EmailSent;
+                    data.ShipfileSent = "Y";
+                }
+            }
+
+            return new ConsignmentShipfile
                                     {
                                         ConsignmentId = data.ConsignmentId,
                                         Id = data.Id,
                                         Consignment = data.Consignment,
                                         Message = data.Message,
                                         ShipfileSent = data.ShipfileSent
-                                    });
-            }
-
-            return withDetails;
+                                    };
         }
-
+        
         private IEnumerable<ConsignmentShipfileEmailModel> BuildEmailModels(ConsignmentShipfile shipfile)
         {
             var toSend = new List<ConsignmentShipfileEmailModel>();

--- a/src/Domain.LinnApps/ConsignmentShipfiles/IConsignmentShipfileService.cs
+++ b/src/Domain.LinnApps/ConsignmentShipfiles/IConsignmentShipfileService.cs
@@ -4,8 +4,8 @@
 
     public interface IConsignmentShipfileService
     {
-        IEnumerable<ConsignmentShipfile> SendEmails(
-            IEnumerable<ConsignmentShipfile> toSend,
+        ConsignmentShipfile SendEmails(
+            ConsignmentShipfile toSend,
             bool test = false,
             string testEmailAddress = null);
     }

--- a/src/Facade/Services/ConsignmentShipfileFacadeService.cs
+++ b/src/Facade/Services/ConsignmentShipfileFacadeService.cs
@@ -43,9 +43,9 @@
                     try
                     {
                         var sent = this.domainService.SendEmails(
-                        new ConsignmentShipfile { Id = resource.Id, ConsignmentId = resource.ConsignmentId },
-                        toSend.Test,
-                        toSend.TestEmailAddress);
+                            new ConsignmentShipfile { Id = resource.Id, ConsignmentId = resource.ConsignmentId },
+                            toSend.Test,
+                            toSend.TestEmailAddress);
                         result.Add(sent);
 
                         this.transactionManager.Commit();

--- a/src/Facade/Services/ConsignmentShipfileFacadeService.cs
+++ b/src/Facade/Services/ConsignmentShipfileFacadeService.cs
@@ -52,7 +52,13 @@
                     }
                     catch (PdfServiceException exception)
                     {
-                        return new ServerFailureResult<IEnumerable<ConsignmentShipfile>>(exception.Message);
+                        return new ServerFailureResult<IEnumerable<ConsignmentShipfile>>(
+                            $"Error building pdf for consignment {resource.ConsignmentId}: {exception.Message}");
+                    }
+                    catch (Exception exception)
+                    {
+                        return new ServerFailureResult<IEnumerable<ConsignmentShipfile>>(
+                            $"Unexpected error creating email for consignment {resource.ConsignmentId}: {exception.Message}");
                     }
                 }
                 

--- a/src/Service.Host/client/src/components/ConsignmentShipfiles.js
+++ b/src/Service.Host/client/src/components/ConsignmentShipfiles.js
@@ -14,7 +14,8 @@ export default function ConsignmentShipfiles({
     itemError,
     clearErrors,
     deleteShipfile,
-    deleteLoading
+    deleteLoading,
+    fetchShipfiles
 }) {
     const [selectedRows, setSelectedRows] = useState([]);
     const [rows, setRows] = useState([]);
@@ -38,6 +39,12 @@ export default function ConsignmentShipfiles({
             );
         }
     }, [processedShipfiles]);
+
+    useEffect(() => {
+        if (itemError) {
+            fetchShipfiles();
+        }
+    }, [itemError, fetchShipfiles]);
 
     const columns = [
         { field: 'id', headerName: 'Id', width: 0, hide: true },
@@ -175,7 +182,7 @@ ConsignmentShipfiles.propTypes = {
         statusText: PropTypes.string,
         details: PropTypes.shape({ errors: PropTypes.arrayOf(PropTypes.string) })
     }),
-    whatToWandReport: PropTypes.shape({})
+    fetchShipfiles: PropTypes.func.isRequired
 };
 
 ConsignmentShipfiles.defaultProps = {
@@ -183,6 +190,5 @@ ConsignmentShipfiles.defaultProps = {
     processedShipfiles: null,
     consignmentShipfilesLoading: false,
     itemError: null,
-    whatToWandReport: null,
     deleteLoading: false
 };

--- a/src/Service.Host/client/src/components/ConsignmentShipfiles.js
+++ b/src/Service.Host/client/src/components/ConsignmentShipfiles.js
@@ -73,7 +73,9 @@ export default function ConsignmentShipfiles({
                             <Grid item xs={12}>
                                 <ErrorCard
                                     errorMessage={
-                                        itemError?.details?.errors?.[0] || itemError.statusText
+                                        itemError?.details?.errors?.[0] ||
+                                        itemError?.details?.message ||
+                                        itemError.statusText
                                     }
                                 />
                             </Grid>
@@ -180,7 +182,10 @@ ConsignmentShipfiles.propTypes = {
     clearErrors: PropTypes.func.isRequired,
     itemError: PropTypes.shape({
         statusText: PropTypes.string,
-        details: PropTypes.shape({ errors: PropTypes.arrayOf(PropTypes.string) })
+        details: PropTypes.shape({
+            message: PropTypes.string,
+            errors: PropTypes.arrayOf(PropTypes.string)
+        })
     }),
     fetchShipfiles: PropTypes.func.isRequired
 };

--- a/src/Service.Host/client/src/containers/ConsignmentShipfiles.js
+++ b/src/Service.Host/client/src/containers/ConsignmentShipfiles.js
@@ -25,6 +25,7 @@ const initialise = () => dispatch => {
 
 const mapDispatchToProps = {
     initialise,
+    fetchShipfiles: consignmentShipfilesActions.fetch,
     sendEmails: shipfilesSendEmailsActions.requestProcessStart,
     clearErrors: shipfilesSendEmailsActions.clearErrorsForItem,
     clearData: shipfilesSendEmailsActions.clearProcessData,

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailAndEmailAlreadySent.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailAndEmailAlreadySent.cs
@@ -12,20 +12,18 @@
 
     public class WhenSendingAnEmailAndEmailAlreadySent : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         [SetUp]
         public void SetUp()
         {
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile
+            this.toSend = new ConsignmentShipfile
                                       {
-                                          Id = 1
-                                      }
-                              };
+                                          Id = 1,
+                                          ConsignmentId = 1
+                                      };
 
             this.ShipfileRepository.FindById(1).Returns(
                 new ConsignmentShipfile { ShipfileSent = "Y", Message = ShipfileStatusMessages.EmailSent });
@@ -49,7 +47,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailAlreadySent);
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailAlreadySent);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailAndEmailAlreadySent.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailAndEmailAlreadySent.cs
@@ -29,6 +29,7 @@
                 new ConsignmentShipfile { ShipfileSent = "Y", Message = ShipfileStatusMessages.EmailSent });
             this.result = this.Sut.SendEmails(this.toSend);
         }
+
         [Test]
         public void ShouldNotSendEmail()
         {

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailToAnIndividual.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailToAnIndividual.cs
@@ -12,9 +12,9 @@
 
     public class WhenSendingAnEmailToAnIndividual : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -40,10 +40,7 @@
                 Id = 1,
                 Consignment = consignment
             };
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1, ConsignmentId = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1, ConsignmentId = 1 };
 
             this.PackingListService.BuildPackingList(Arg.Any<IEnumerable<PackingListItem>>())
                 .ReturnsForAnyArgs(new List<PackingListItem> { new PackingListItem(1, 1, "desc", 1m) });
@@ -83,8 +80,8 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailSent);
-            this.result.First().ShipfileSent.Should().Be("Y");
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailSent);
+            this.result.ShipfileSent.Should().Be("Y");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailAndNoOutletAddressOrAccountAddress.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailAndNoOutletAddressOrAccountAddress.cs
@@ -14,9 +14,9 @@
 
     public class WhenSendingEmailAndNoOutletAddressOrAccountAddress : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -58,10 +58,7 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -97,7 +94,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.NoContactDetails);
+            this.result.Message.Should().Be(ShipfileStatusMessages.NoContactDetails);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailAndNoOutletEmailAddressButOutletIsOnlyOneForAccountWhichHasEmailAddress.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailAndNoOutletEmailAddressButOutletIsOnlyOneForAccountWhichHasEmailAddress.cs
@@ -14,9 +14,9 @@
 
     public class WhenSendingEmailAndNoOutletEmailAddressButOutletIsOnlyOneForAccountWhichHasEmailAddress : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -59,10 +59,7 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -99,7 +96,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailSent);
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailSent);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnIndividualAndContactDetailsMissing.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnIndividualAndContactDetailsMissing.cs
@@ -12,9 +12,9 @@
 
     public class WhenSendingEmailToAnIndividualAndContactDetailsMissing : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -26,21 +26,17 @@
                 Id = 1,
                 Consignment = new Consignment
                 {
-                    SalesAccount =
-                                                              new SalesAccount
-                                                              {
-                                                                  OrgId = null,
-                                                                  ContactDetails = new Contact()
-                                                              }
+                    SalesAccount = new SalesAccount
+                                       {
+                                           OrgId = null,
+                                           ContactDetails = new Contact()
+                                       }
                 }
             };
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile
+            this.toSend = new ConsignmentShipfile
                                       {
                                           Id = 1,
-                                      }
-                              };
+                                      };
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -64,7 +60,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.NoContactDetails);
+            this.result.Message.Should().Be(ShipfileStatusMessages.NoContactDetails);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnOrg.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailToAnOrg.cs
@@ -14,9 +14,9 @@
 
     public class WhenSendingEmailToAnOrg : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -64,10 +64,7 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -113,8 +110,8 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailSent);
-            this.result.First().ShipfileSent.Should().Be("Y");
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailSent);
+            this.result.ShipfileSent.Should().Be("Y");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailsToAnOrgAndContactDetailsMissingForAnOutlet.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailsToAnOrgAndContactDetailsMissingForAnOutlet.cs
@@ -14,9 +14,9 @@
 
     public class WhenSendingEmailsToAnOrgAndContactDetailsMissingForAnOutlet : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -64,10 +64,7 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
 
             this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
 
@@ -99,7 +96,7 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.NoContactDetailsForAnOutlet);
+            this.result.Message.Should().Be(ShipfileStatusMessages.NoContactDetailsForAnOutlet);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailsToAnOrgAndContactDetailsMissingForAnOutlet.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingEmailsToAnOrgAndContactDetailsMissingForAnOutlet.cs
@@ -37,10 +37,7 @@
                                                             {
                                                                 AccountId = 1,
                                                                 OutletNumber = 1,
-                                                                OrderContact = new Contact
-                                                                                   {
-                                                                                       EmailAddress = null
-                                                                                   }
+                                                                OrderContact = null
                                                             }
                                       },
                                   new SalesOrder

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingToAnOrgWithMultipleOutletsWithTheSameEmailAddress.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingToAnOrgWithMultipleOutletsWithTheSameEmailAddress.cs
@@ -14,9 +14,9 @@
 
     public class WhenSendingEmailToAnOrgWithMultipleOutletsWithTheSameEmailAddress : ContextBase
     {
-        private IEnumerable<ConsignmentShipfile> toSend;
+        private ConsignmentShipfile toSend;
 
-        private IEnumerable<ConsignmentShipfile> result;
+        private ConsignmentShipfile result;
 
         private ConsignmentShipfile shipfileData;
 
@@ -64,10 +64,8 @@
                 Consignment = consignment
             };
 
-            this.toSend = new List<ConsignmentShipfile>
-                              {
-                                  new ConsignmentShipfile { Id = 1 }
-                              };
+            this.toSend = new ConsignmentShipfile { Id = 1 };
+                              
 
             this.PackingListService.BuildPackingList(Arg.Any<IEnumerable<PackingListItem>>())
                 .ReturnsForAnyArgs(new List<PackingListItem> { new PackingListItem(1, 1, "desc", 1m) });
@@ -113,8 +111,8 @@
         [Test]
         public void ShouldUpdateStatusMessage()
         {
-            this.result.First().Message.Should().Be(ShipfileStatusMessages.EmailSent);
-            this.result.First().ShipfileSent.Should().Be("Y");
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailSent);
+            this.result.ShipfileSent.Should().Be("Y");
         }
     }
 }

--- a/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/ContextBase.cs
+++ b/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/ContextBase.cs
@@ -1,0 +1,33 @@
+﻿namespace Linn.Stores.Facade.Tests.ConsignmentShipfilesFacadeServiceTests
+{
+    using Linn.Common.Persistence;
+    using Linn.Stores.Domain.LinnApps.ConsignmentShipfiles;
+    using Linn.Stores.Facade.Services;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class ContextBase
+    {
+        protected IConsignmentShipfileFacadeService Sut { get; private set; }
+
+        protected ITransactionManager TransactionManager { get; private set; }
+
+        protected IRepository<ConsignmentShipfile, int> Repository { get; private set; }
+
+        protected IConsignmentShipfileService DomainService { get; private set; }
+
+        [SetUp]
+        public void SetUpContext()
+        {
+            this.TransactionManager = Substitute.For<ITransactionManager>();
+            this.Repository = Substitute.For<IRepository<ConsignmentShipfile, int>>();
+            this.DomainService = Substitute.For<IConsignmentShipfileService>();
+            this.Sut = new ConsignmentShipfileFacadeService(
+                this.Repository,
+                this.DomainService,
+                this.TransactionManager);
+        }
+    }
+}

--- a/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmails.cs
+++ b/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmails.cs
@@ -52,7 +52,6 @@
             this.TransactionManager.Received(3).Commit();
         }
 
-
         [Test]
         public void ShouldReturnSuccess()
         {

--- a/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmails.cs
+++ b/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmails.cs
@@ -1,0 +1,67 @@
+﻿namespace Linn.Stores.Facade.Tests.ConsignmentShipfilesFacadeServiceTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using FluentAssertions;
+
+    using Linn.Common.Facade;
+    using Linn.Stores.Domain.LinnApps.ConsignmentShipfiles;
+    using Linn.Stores.Resources;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenSendingEmails : ContextBase
+    {
+        private IResult<IEnumerable<ConsignmentShipfile>> result;
+
+        private ConsignmentShipfilesSendEmailsRequestResource requestResource;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.requestResource = new ConsignmentShipfilesSendEmailsRequestResource
+                                       {
+                                           Shipfiles = new List<ConsignmentShipfileResource>
+                                                           {
+                                                               new ConsignmentShipfileResource { ConsignmentId = 1 },
+                                                               new ConsignmentShipfileResource { ConsignmentId = 2 },
+                                                               new ConsignmentShipfileResource { ConsignmentId = 3 },
+                                                           }
+            };
+
+            this.DomainService.SendEmails(Arg.Any<ConsignmentShipfile>()).Returns(
+                new ConsignmentShipfile { ConsignmentId = 1 },
+                new ConsignmentShipfile { ConsignmentId = 2 },
+                new ConsignmentShipfile { ConsignmentId = 3 });
+
+            this.result = this.Sut.SendEmails(this.requestResource);
+        }
+
+        [Test]
+        public void ShouldCallDomainServiceMethodCorrectNumberOfTimes()
+        {
+            this.DomainService.Received(3).SendEmails(Arg.Any<ConsignmentShipfile>());
+        }
+
+        [Test]
+        public void ShouldCommitChanges()
+        {
+            this.TransactionManager.Received(3).Commit();
+        }
+
+
+        [Test]
+        public void ShouldReturnSuccess()
+        {
+            this.result.Should().BeOfType<SuccessResult<IEnumerable<ConsignmentShipfile>>>();
+            var dataResult = (SuccessResult<IEnumerable<ConsignmentShipfile>>)this.result;
+            dataResult.Data.Count().Should().Be(3);
+            dataResult.Data.ElementAt(0).ConsignmentId.Should().Be(1);
+            dataResult.Data.ElementAt(1).ConsignmentId.Should().Be(2);
+            dataResult.Data.ElementAt(2).ConsignmentId.Should().Be(3);
+        }
+    }
+}

--- a/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmailsAndAnEmailErrors.cs
+++ b/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmailsAndAnEmailErrors.cs
@@ -54,7 +54,6 @@
             this.TransactionManager.Received(2).Commit();
         }
 
-
         [Test]
         public void ShouldReturnServerFailure()
         {

--- a/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmailsAndAnEmailErrors.cs
+++ b/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmailsAndAnEmailErrors.cs
@@ -1,0 +1,66 @@
+﻿namespace Linn.Stores.Facade.Tests.ConsignmentShipfilesFacadeServiceTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using FluentAssertions;
+
+    using Linn.Common.Facade;
+    using Linn.Stores.Domain.LinnApps.ConsignmentShipfiles;
+    using Linn.Stores.Proxy;
+    using Linn.Stores.Resources;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenSendingEmailsAndAnEmailErrors : ContextBase
+    {
+        private IResult<IEnumerable<ConsignmentShipfile>> result;
+
+        private ConsignmentShipfilesSendEmailsRequestResource requestResource;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.requestResource = new ConsignmentShipfilesSendEmailsRequestResource
+            {
+                Shipfiles = new List<ConsignmentShipfileResource>
+                                                           {
+                                                               new ConsignmentShipfileResource { ConsignmentId = 1 },
+                                                               new ConsignmentShipfileResource { ConsignmentId = 2 },
+                                                               new ConsignmentShipfileResource { ConsignmentId = 3 },
+                                                           }
+            };
+
+            this.DomainService.SendEmails(Arg.Any<ConsignmentShipfile>())
+                .Returns(
+                x => new ConsignmentShipfile { ConsignmentId = 1 },
+                x => new ConsignmentShipfile { ConsignmentId = 2 },
+                x => throw new PdfServiceException("Something broke"));
+            
+            this.result = this.Sut.SendEmails(this.requestResource);
+        }
+
+        [Test]
+        public void ShouldCallDomainServiceMethodCorrectNumberOfTimes()
+        {
+            this.DomainService.Received(3).SendEmails(Arg.Any<ConsignmentShipfile>());
+        }
+
+        [Test]
+        public void ShouldCommitChangesForEmailsBeforeErroringEmail()
+        {
+            this.TransactionManager.Received(2).Commit();
+        }
+
+
+        [Test]
+        public void ShouldReturnServerFailure()
+        {
+            this.result.Should().BeOfType<ServerFailureResult<IEnumerable<ConsignmentShipfile>>>();
+            var dataResult = (ServerFailureResult<IEnumerable<ConsignmentShipfile>>)this.result;
+            dataResult.Message.Should().Be("Something broke");
+        }
+    }
+}

--- a/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmailsAndEmailCreationFails.cs
+++ b/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmailsAndEmailCreationFails.cs
@@ -1,0 +1,64 @@
+﻿namespace Linn.Stores.Facade.Tests.ConsignmentShipfilesFacadeServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Common.Facade;
+    using Linn.Stores.Domain.LinnApps.ConsignmentShipfiles;
+    using Linn.Stores.Resources;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenSendingEmailsAndEmailCreationFails : ContextBase
+    {
+        private IResult<IEnumerable<ConsignmentShipfile>> result;
+
+        private ConsignmentShipfilesSendEmailsRequestResource requestResource;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.requestResource = new ConsignmentShipfilesSendEmailsRequestResource
+            {
+                Shipfiles = new List<ConsignmentShipfileResource>
+                                                           {
+                                                               new ConsignmentShipfileResource { ConsignmentId = 1 },
+                                                               new ConsignmentShipfileResource { ConsignmentId = 2 },
+                                                               new ConsignmentShipfileResource { ConsignmentId = 3 },
+                                                           }
+            };
+
+            this.DomainService.SendEmails(Arg.Any<ConsignmentShipfile>())
+                .Returns(
+                x => new ConsignmentShipfile { ConsignmentId = 1 },
+                x => new ConsignmentShipfile { ConsignmentId = 2 },
+                x => throw new Exception("Something broke unexpectedly"));
+
+            this.result = this.Sut.SendEmails(this.requestResource);
+        }
+
+        [Test]
+        public void ShouldCallDomainServiceMethodCorrectNumberOfTimes()
+        {
+            this.DomainService.Received(3).SendEmails(Arg.Any<ConsignmentShipfile>());
+        }
+
+        [Test]
+        public void ShouldCommitChangesForEmailsBeforeErroringEmail()
+        {
+            this.TransactionManager.Received(2).Commit();
+        }
+
+        [Test]
+        public void ShouldReturnServerFailure()
+        {
+            this.result.Should().BeOfType<ServerFailureResult<IEnumerable<ConsignmentShipfile>>>();
+            var dataResult = (ServerFailureResult<IEnumerable<ConsignmentShipfile>>)this.result;
+            dataResult.Message.Should().Be("Unexpected error creating email for consignment 3: Something broke unexpectedly");
+        }
+    }
+}

--- a/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmailsAndPdfCreationErrors.cs
+++ b/tests/Unit/Facade.Tests/ConsignmentShipfilesFacadeServiceTests/WhenSendingEmailsAndPdfCreationErrors.cs
@@ -1,7 +1,6 @@
 ﻿namespace Linn.Stores.Facade.Tests.ConsignmentShipfilesFacadeServiceTests
 {
     using System.Collections.Generic;
-    using System.Linq;
 
     using FluentAssertions;
 
@@ -14,7 +13,7 @@
 
     using NUnit.Framework;
 
-    public class WhenSendingEmailsAndAnEmailErrors : ContextBase
+    public class WhenSendingEmailsAndPdfCreationErrors : ContextBase
     {
         private IResult<IEnumerable<ConsignmentShipfile>> result;
 
@@ -59,7 +58,7 @@
         {
             this.result.Should().BeOfType<ServerFailureResult<IEnumerable<ConsignmentShipfile>>>();
             var dataResult = (ServerFailureResult<IEnumerable<ConsignmentShipfile>>)this.result;
-            dataResult.Message.Should().Be("Something broke");
+            dataResult.Message.Should().Be("Error building pdf for consignment 3: Something broke");
         }
     }
 }

--- a/tests/Unit/Facade.Tests/LogisticsProcessesFacadeServiceTests/WhenPrintingPalletLabelFails.cs
+++ b/tests/Unit/Facade.Tests/LogisticsProcessesFacadeServiceTests/WhenPrintingPalletLabelFails.cs
@@ -53,7 +53,7 @@
         }
 
         [Test]
-        public void ShouldReturnSuccess()
+        public void ShouldReturnFailResult()
         {
             this.result.Should().BeOfType<BadRequestResult<ProcessResult>>();
             var dataResult = (BadRequestResult<ProcessResult>)this.result;


### PR DESCRIPTION
- git diff is making it hard to see whats going on here so: 
- Basically I've moved the loop over all emails-to-be-sent that arrives in the requestResource from the domain to the facade. 
- This is so that I can do transactionManager.Commit()'s on a per email basis so the database gets updated to know which emails sent and which ones didn't in the case of errors. 
- Previously the domain just threw an exception if an email errored and the whole request 500'ed with no data persisting regarding which emails were sent
- see new facade unit tests for clarity