### PR TITLE
kill parcel ut fields added + front end permission checks

### DIFF
--- a/src/Service.Host/client/src/components/__tests__/Parcel.test.js
+++ b/src/Service.Host/client/src/components/__tests__/Parcel.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { cleanup } from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
 import render from '../../test-utils';
 import Parcel from '../parcels/Parcel';
 
@@ -149,4 +149,121 @@ test('On View -  page renders populated fields', () => {
 
     expect(getByDisplayValue(item.importBookNos[0])).toBeInTheDocument();
     expect(getByDisplayValue(item.importBookNos[1])).toBeInTheDocument();
+});
+
+describe('When have no permissions/privileges', () => {
+    beforeEach(() => {
+        render(
+            <Parcel
+                item={item}
+                editStatus="view"
+                fetchItems={fetchItems}
+                searchCarriers={searchCarriers}
+                searchSuppliers={searchSuppliers}
+                clearCarriersSearch={clearCarriersSearch}
+                clearSuppliersSearch={clearSuppliersSearch}
+                history={history}
+                suppliers={suppliers}
+                employees={employees}
+                addItem={addItem}
+                updateItem={updateItem}
+                setEditStatus={setEditStatus}
+                setSnackbarVisible={setSnackbarVisible}
+                userNumber={118}
+                privileges={[]}
+            />
+        );
+    });
+
+    test('cannot edit fields', () => {
+        expect(screen.getByLabelText('Supplier')).toBeDisabled();
+        expect(screen.getByLabelText('Carrier')).toBeDisabled();
+
+        expect(screen.getByLabelText('Supplier Invoice Number(s)')).toBeDisabled();
+
+        expect(screen.getByLabelText('Number of cartons')).toBeDisabled();
+        expect(screen.getByLabelText('Number of pallets')).toBeDisabled();
+
+        expect(screen.getByLabelText('Comments')).toBeDisabled();
+
+        expect(screen.getByLabelText('Cancellation Reason')).toBeDisabled();
+    });
+});
+
+describe('When have admin permission', () => {
+    beforeEach(() => {
+        render(
+            <Parcel
+                item={item}
+                editStatus="view"
+                fetchItems={fetchItems}
+                searchCarriers={searchCarriers}
+                searchSuppliers={searchSuppliers}
+                clearCarriersSearch={clearCarriersSearch}
+                clearSuppliersSearch={clearSuppliersSearch}
+                history={history}
+                suppliers={suppliers}
+                employees={employees}
+                addItem={addItem}
+                updateItem={updateItem}
+                setEditStatus={setEditStatus}
+                setSnackbarVisible={setSnackbarVisible}
+                userNumber={118}
+                privileges={['parcel.admin']}
+            />
+        );
+    });
+
+    test('can edit fields but not kill', () => {
+        expect(screen.getByLabelText('Supplier')).not.toBeDisabled();
+        expect(screen.getByLabelText('Carrier')).not.toBeDisabled();
+
+        expect(screen.getByLabelText('Supplier Invoice Number(s)')).not.toBeDisabled();
+
+        expect(screen.getByLabelText('Number of cartons')).not.toBeDisabled();
+        expect(screen.getByLabelText('Number of pallets')).not.toBeDisabled();
+
+        expect(screen.getByLabelText('Comments')).not.toBeDisabled();
+
+        expect(screen.getByLabelText('Cancellation Reason')).toBeDisabled();
+    });
+});
+
+describe('When have admin permission and kill permission', () => {
+    beforeEach(() => {
+        render(
+            <Parcel
+                item={item}
+                editStatus="view"
+                fetchItems={fetchItems}
+                searchCarriers={searchCarriers}
+                searchSuppliers={searchSuppliers}
+                clearCarriersSearch={clearCarriersSearch}
+                clearSuppliersSearch={clearSuppliersSearch}
+                history={history}
+                suppliers={suppliers}
+                employees={employees}
+                addItem={addItem}
+                updateItem={updateItem}
+                setEditStatus={setEditStatus}
+                setSnackbarVisible={setSnackbarVisible}
+                userNumber={118}
+                privileges={['parcel.admin', 'parcel-kill.admin']}
+            />
+        );
+    });
+
+    test('can edit fields and edit kill fields', () => {
+        expect(screen.getByLabelText('Supplier')).not.toBeDisabled();
+        expect(screen.getByLabelText('Carrier')).not.toBeDisabled();
+
+        expect(screen.getByLabelText('Supplier Invoice Number(s)')).not.toBeDisabled();
+
+        expect(screen.getByLabelText('Number of cartons')).not.toBeDisabled();
+        expect(screen.getByLabelText('Number of pallets')).not.toBeDisabled();
+
+        expect(screen.getByLabelText('Comments')).not.toBeDisabled();
+
+        expect(screen.getByLabelText('Cancellation Reason')).not.toBeDisabled();
+    });
 });

--- a/src/Service.Host/client/src/components/parcels/ParcelsSearch.js
+++ b/src/Service.Host/client/src/components/parcels/ParcelsSearch.js
@@ -41,10 +41,7 @@ function ParcelsSearch({
     const [rowsToDisplay, setRowsToDisplay] = useState([]);
 
     const allowedToCreate = () => {
-        if (!(privileges.length < 1)) {
-            return privileges.some(priv => priv === 'parcel.admin');
-        }
-        return false;
+        return privileges?.some(priv => priv === 'parcel.admin');
     };
 
     const useStyles = makeStyles(theme => ({
@@ -245,9 +242,11 @@ function ParcelsSearch({
             <Grid spacing={3} container justifyContent="center">
                 <Grid item xs={11} />
                 <Grid item xs={1}>
-                    {(allowedToCreate || true) && (
-                        <LinkButton text="Create" to="/logistics/parcels/create" />
-                    )}
+                    <LinkButton
+                        text="Create"
+                        to="/logistics/parcels/create"
+                        disabled={!allowedToCreate()}
+                    />
                 </Grid>
                 <Grid item xs={3}>
                     <SearchInputField
@@ -399,7 +398,7 @@ ParcelsSearch.propTypes = {
     loading: PropTypes.bool,
     fetchItems: PropTypes.func.isRequired,
     history: PropTypes.shape({ push: PropTypes.func }).isRequired,
-    privileges: PropTypes.arrayOf(PropTypes.string),
+    privileges: PropTypes.arrayOf(PropTypes.string).isRequired,
     suppliersSearchResults: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.number,
@@ -427,7 +426,6 @@ ParcelsSearch.defaultProps = {
     carriersSearchResults: [],
     suppliersSearchResults: [],
     suppliers: [],
-    privileges: null,
     carriersSearchLoading: false,
     suppliersSearchLoading: false
 };

--- a/src/Service.Host/client/src/containers/parcels/Parcels.js
+++ b/src/Service.Host/client/src/containers/parcels/Parcels.js
@@ -22,7 +22,6 @@ const mapStateToProps = state => ({
         .getSearchItems(state)
         .map(c => ({ id: c.id, name: c.id.toString(), description: c.name })),
     carriersSearchLoading: suppliersApprovedCarrierSelectors.getSearchLoading(state)
-    // editStatus: parcelSelectors.getEditStatus(state)
 });
 
 const initialise = () => dispatch => {


### PR DESCRIPTION
Backend already had these fields. Will need to give goods in the admin priv and the orders team 00s the licence to kill before I merge this

Added front end authoriation permission checks, should probs do some back end checks for these too - 
did anyone do backend authorisation checks in stores? Where'd we settle on putting them, facade?

Think I still have impbook backend checks to add too - might do them both on a new branch.

