### PR TITLE
Impbook - allow mismatched weights

### DIFF
--- a/src/Service.Host/client/src/components/__tests__/impbooks/Impbook.test.js
+++ b/src/Service.Host/client/src/components/__tests__/impbooks/Impbook.test.js
@@ -79,6 +79,61 @@ const item = {
     totalImportValue: 1000
 };
 
+const cpcNumbers = [
+    {
+        cpcNumber: 1,
+        description: '51 00 00'
+    },
+    {
+        cpcNumber: 2,
+        description: '51 00 01'
+    },
+    {
+        cpcNumber: 3,
+        description: '40 00 00'
+    },
+    {
+        cpcNumber: 4,
+        description: '40 00 60'
+    },
+    {
+        cpcNumber: 5,
+        description: '40 00 63'
+    },
+    {
+        cpcNumber: 6,
+        description: 'EC Countries'
+    },
+    {
+        cpcNumber: 7,
+        description: '40 00 09 - SAMPLES ONLY'
+    },
+    {
+        cpcNumber: 8,
+        description: 'Low Value Shipment'
+    },
+    {
+        cpcNumber: 9,
+        description: '40 51 00 - IPR to Free'
+    },
+    {
+        cpcNumber: 10,
+        description: '40 00 58'
+    },
+    {
+        cpcNumber: 11,
+        description: '61 23 F01'
+    },
+    {
+        cpcNumber: 12,
+        description: '40 00 000'
+    },
+    {
+        cpcNumber: 13,
+        description: '51 00 000'
+    }
+];
+
 const privileges = ['potato.admin', 'import-books.admin'];
 
 describe('When loading', () => {
@@ -116,6 +171,7 @@ describe('On Create', () => {
                 getExchangeRatesForDate={getExchangeRatesForDate}
                 privileges={privileges}
                 loading={false}
+                cpcNumbers={cpcNumbers}
             />
         );
     });
@@ -190,6 +246,7 @@ describe('When dont have right privilege', () => {
                 getExchangeRatesForDate={getExchangeRatesForDate}
                 privileges={['not-right.priv']}
                 loading={false}
+                cpcNumbers={cpcNumbers}
             />
         );
     });
@@ -219,6 +276,7 @@ describe('When editing', () => {
                 privileges={privileges}
                 loading={false}
                 item={item}
+                cpcNumbers={cpcNumbers}
             />
         );
     });
@@ -257,6 +315,7 @@ describe('When clicking through to second tab', () => {
                 privileges={privileges}
                 loading={false}
                 item={item}
+                cpcNumbers={cpcNumbers}
             />
         );
 

--- a/src/Service.Host/client/src/components/__tests__/impbooks/Impbook.test.js
+++ b/src/Service.Host/client/src/components/__tests__/impbooks/Impbook.test.js
@@ -79,58 +79,58 @@ const item = {
     totalImportValue: 1000
 };
 
-const cpcNumbers = [
+const cpcNumbers = () => [
     {
-        cpcNumber: 1,
-        description: '51 00 00'
+        id: 1,
+        displayText: '51 00 00'
     },
     {
-        cpcNumber: 2,
-        description: '51 00 01'
+        id: 2,
+        displayText: '51 00 01'
     },
     {
-        cpcNumber: 3,
-        description: '40 00 00'
+        id: 3,
+        displayText: '40 00 00'
     },
     {
-        cpcNumber: 4,
-        description: '40 00 60'
+        id: 4,
+        displayText: '40 00 60'
     },
     {
-        cpcNumber: 5,
-        description: '40 00 63'
+        id: 5,
+        displayText: '40 00 63'
     },
     {
-        cpcNumber: 6,
-        description: 'EC Countries'
+        id: 6,
+        displayText: 'EC Countries'
     },
     {
-        cpcNumber: 7,
-        description: '40 00 09 - SAMPLES ONLY'
+        id: 7,
+        displayText: '40 00 09 - SAMPLES ONLY'
     },
     {
-        cpcNumber: 8,
-        description: 'Low Value Shipment'
+        id: 8,
+        displayText: 'Low Value Shipment'
     },
     {
-        cpcNumber: 9,
-        description: '40 51 00 - IPR to Free'
+        id: 9,
+        displayText: '40 51 00 - IPR to Free'
     },
     {
-        cpcNumber: 10,
-        description: '40 00 58'
+        id: 10,
+        displayText: '40 00 58'
     },
     {
-        cpcNumber: 11,
-        description: '61 23 F01'
+        id: 11,
+        displayText: '61 23 F01'
     },
     {
-        cpcNumber: 12,
-        description: '40 00 000'
+        id: 12,
+        displayText: '40 00 000'
     },
     {
-        cpcNumber: 13,
-        description: '51 00 000'
+        id: 13,
+        displayText: '51 00 000'
     }
 ];
 
@@ -171,7 +171,7 @@ describe('On Create', () => {
                 getExchangeRatesForDate={getExchangeRatesForDate}
                 privileges={privileges}
                 loading={false}
-                cpcNumbers={cpcNumbers}
+                cpcNumbers={cpcNumbers()}
             />
         );
     });
@@ -246,7 +246,7 @@ describe('When dont have right privilege', () => {
                 getExchangeRatesForDate={getExchangeRatesForDate}
                 privileges={['not-right.priv']}
                 loading={false}
-                cpcNumbers={cpcNumbers}
+                cpcNumbers={cpcNumbers()}
             />
         );
     });
@@ -276,7 +276,7 @@ describe('When editing', () => {
                 privileges={privileges}
                 loading={false}
                 item={item}
-                cpcNumbers={cpcNumbers}
+                cpcNumbers={cpcNumbers()}
             />
         );
     });
@@ -315,7 +315,7 @@ describe('When clicking through to second tab', () => {
                 privileges={privileges}
                 loading={false}
                 item={item}
-                cpcNumbers={cpcNumbers}
+                cpcNumbers={cpcNumbers()}
             />
         );
 

--- a/src/Service.Host/client/src/components/importBooks/ImpBookPrintOut.js
+++ b/src/Service.Host/client/src/components/importBooks/ImpBookPrintOut.js
@@ -43,7 +43,8 @@ function ImpBookPrintOut({
     orderDetails,
     comments,
     arrivalPort,
-    pva
+    pva,
+    cpcNumbers
 }) {
     const useStyles = makeStyles(theme => ({
         gapAbove: {
@@ -58,6 +59,10 @@ function ImpBookPrintOut({
 
     const getNicerDate = date => {
         return date ? moment(date).format('DD-MMM-YYYY') : '-';
+    };
+
+    const getCpcNumber = id => {
+        return cpcNumbers.find(x => x.id === id)?.displayText;
     };
 
     return (
@@ -300,7 +305,11 @@ function ImpBookPrintOut({
                             </Grid>
                             <Grid item xs={2}>
                                 <InputLabel>Cpc Number</InputLabel>
-                                <TextField value={row.cpcNumber} variant="standard" fullWidth />
+                                <TextField
+                                    value={getCpcNumber(row.cpcNumber)}
+                                    variant="standard"
+                                    fullWidth
+                                />
                             </Grid>
 
                             <Grid item xs={12}>
@@ -351,7 +360,8 @@ ImpBookPrintOut.propTypes = {
     remainingInvoiceValue: PropTypes.number,
     remainingDutyValue: PropTypes.number,
     remainingWeightValue: PropTypes.number,
-    pva: PropTypes.string
+    pva: PropTypes.string,
+    cpcNumbers: PropTypes.arrayOf(PropTypes.shape({})).isRequired
 };
 
 ImpBookPrintOut.defaultProps = {

--- a/src/Service.Host/client/src/components/importBooks/tabs/OrderDetailsTab.js
+++ b/src/Service.Host/client/src/components/importBooks/tabs/OrderDetailsTab.js
@@ -306,112 +306,80 @@ function OrderDetailsTab({
                                 />
                             </Grid>
                             {(row.lineType === 'PO' || row.lineType === 'RO') && (
-                                <Grid item xs={3}>
-                                    <div className={classes.displayInline}>
-                                        <Typeahead
-                                            label="Order Number"
-                                            propertyName="orderNumber"
-                                            title="Search for an Order Number"
-                                            onSelect={newOrder =>
-                                                handleOrderNoUpdate(row, newOrder)
-                                            }
-                                            items={purchaseOrdersSearchResults}
-                                            loading={purchaseOrdersSearchLoading}
-                                            fetchItems={searchPurchaseOrders}
-                                            clearSearch={() => clearPurchaseOrdersSearch}
-                                            value={row.orderNumber}
-                                            modal
-                                            links={false}
-                                            debounce={1000}
-                                            minimumSearchTermLength={2}
-                                            required
-                                            disabled={!allowedToEdit}
-                                            maxLength={6}
-                                        />
-                                    </div>
-                                    <div className={classes.marginTop1}>
-                                        <Tooltip title="Clear Order No search">
-                                            <Button
-                                                variant="outlined"
-                                                onClick={() => editRow(row, 'orderNumber', '')}
-                                                disabled={!allowedToEdit}
-                                            >
-                                                X
-                                            </Button>
-                                        </Tooltip>
-                                    </div>
+                                <Grid item xs={4}>
+                                    <Typeahead
+                                        label="Order Number"
+                                        propertyName="orderNumber"
+                                        title="Search for an Order Number"
+                                        onSelect={newOrder => handleOrderNoUpdate(row, newOrder)}
+                                        items={purchaseOrdersSearchResults}
+                                        loading={purchaseOrdersSearchLoading}
+                                        fetchItems={searchPurchaseOrders}
+                                        clearSearch={() => clearPurchaseOrdersSearch}
+                                        value={row.orderNumber}
+                                        modal
+                                        links={false}
+                                        debounce={1000}
+                                        minimumSearchTermLength={2}
+                                        required
+                                        disabled={!allowedToEdit}
+                                        maxLength={6}
+                                        clearable
+                                        onClear={() => editRow(row, 'orderNumber', '')}
+                                        clearTooltipText="Clear Order No search"
+                                    />
                                 </Grid>
                             )}
                             {row.lineType === 'RSN' && (
-                                <Grid item xs={3}>
-                                    <div className={classes.displayInline}>
-                                        <Typeahead
-                                            label="RSN Number"
-                                            propertyName="rsnNumber"
-                                            title="Search for an rsn"
-                                            onSelect={newRsn => handleRsnUpdate(row, newRsn)}
-                                            items={rsnsSearchResults}
-                                            loading={rsnsSearchLoading}
-                                            fetchItems={searchRsns}
-                                            clearSearch={() => clearRsnsSearch}
-                                            value={row.rsnNumber}
-                                            modal
-                                            links={false}
-                                            debounce={1000}
-                                            minimumSearchTermLength={2}
-                                            required
-                                            disabled={!allowedToEdit}
-                                            maxLength={6}
-                                        />
-                                    </div>
-                                    <div className={classes.marginTop1}>
-                                        <Tooltip title="Clear Rsn search">
-                                            <Button
-                                                variant="outlined"
-                                                onClick={() => editRow(row, 'rsnNumber', '')}
-                                                disabled={!allowedToEdit}
-                                            >
-                                                X
-                                            </Button>
-                                        </Tooltip>
-                                    </div>
+                                <Grid item xs={4}>
+                                    <Typeahead
+                                        label="RSN Number"
+                                        propertyName="rsnNumber"
+                                        title="Search for an rsn"
+                                        onSelect={newRsn => handleRsnUpdate(row, newRsn)}
+                                        items={rsnsSearchResults}
+                                        loading={rsnsSearchLoading}
+                                        fetchItems={searchRsns}
+                                        clearSearch={() => clearRsnsSearch}
+                                        value={row.rsnNumber}
+                                        modal
+                                        links={false}
+                                        debounce={1000}
+                                        minimumSearchTermLength={2}
+                                        required
+                                        disabled={!allowedToEdit}
+                                        maxLength={6}
+                                        clearable
+                                        onClear={() => editRow(row, 'rsnNumber', '')}
+                                        clearTooltipText="Clear Rsn search"
+                                    />
                                 </Grid>
                             )}
                             {row.lineType === 'LOAN' && (
-                                <Grid item xs={3}>
-                                    <div className={classes.displayInline}>
-                                        <Typeahead
-                                            label="Loan Number"
-                                            propertyName="loanNumber"
-                                            title="Search for a Loan Number"
-                                            onSelect={newValue =>
-                                                editRow(row, 'loanNumber', newValue.id)
-                                            }
-                                            items={loansSearchResults}
-                                            loading={loansSearchLoading}
-                                            fetchItems={searchLoans}
-                                            clearSearch={() => clearLoansSearch}
-                                            value={row.loanNumber}
-                                            modal
-                                            links={false}
-                                            debounce={1000}
-                                            minimumSearchTermLength={2}
-                                            required
-                                            disabled={!allowedToEdit}
-                                            maxLength={6}
-                                        />
-                                    </div>
-                                    <div className={classes.marginTop1}>
-                                        <Tooltip title="Clear Loan Number search">
-                                            <Button
-                                                variant="outlined"
-                                                onClick={() => editRow(row, 'loanNumber', '')}
-                                                disabled={!allowedToEdit}
-                                            >
-                                                X
-                                            </Button>
-                                        </Tooltip>
-                                    </div>
+                                <Grid item xs={4}>
+                                    <Typeahead
+                                        label="Loan Number"
+                                        propertyName="loanNumber"
+                                        title="Search for a Loan Number"
+                                        onSelect={newValue =>
+                                            editRow(row, 'loanNumber', newValue.id)
+                                        }
+                                        items={loansSearchResults}
+                                        loading={loansSearchLoading}
+                                        fetchItems={searchLoans}
+                                        clearSearch={() => clearLoansSearch}
+                                        value={row.loanNumber}
+                                        modal
+                                        links={false}
+                                        debounce={1000}
+                                        minimumSearchTermLength={2}
+                                        required
+                                        disabled={!allowedToEdit}
+                                        maxLength={6}
+                                        clearable
+                                        onClear={() => editRow(row, 'loanNumber', '')}
+                                        clearTooltipText="Clear Loan Number search"
+                                    />
                                 </Grid>
                             )}
                             {row.lineType === 'INS' && (

--- a/src/Service.Host/client/src/containers/importBooks/ImportBook.js
+++ b/src/Service.Host/client/src/containers/importBooks/ImportBook.js
@@ -13,6 +13,8 @@ import employeesActions from '../../actions/employeesActions';
 import employeesSelectors from '../../selectors/employeesSelectors';
 import exchangeRatesActions from '../../actions/exchangeRatesActions';
 import exchangeRatesSelectors from '../../selectors/exchangeRatesSelectors';
+import cpcNumbersActions from '../../actions/impbookCpcNumbersActions';
+import cpcNumbersSelectors from '../../selectors/impbookCpcNumbersSelectors';
 
 const creating = match => match?.url?.endsWith('/create');
 
@@ -28,7 +30,13 @@ const mapStateToProps = (state, { match }) => ({
     allSuppliers: suppliersSelectors.getItems(state),
     countries: countriesSelectors.getItems(state),
     employees: employeesSelectors.getItems(state),
-    exchangeRates: exchangeRatesSelectors.getSearchItems(state)
+    exchangeRates: exchangeRatesSelectors.getSearchItems(state),
+    cpcNumbers: cpcNumbersSelectors.getItems(state)?.map(x => ({
+        displayText: `${x.cpcNumber === 13 ? `${x.cpcNumber} (IPR)` : x.cpcNumber} - ${
+            x.description
+        }`,
+        id: parseInt(x.cpcNumber, 10)
+    }))
 });
 
 const initialise = ({ itemId }) => dispatch => {
@@ -38,6 +46,7 @@ const initialise = ({ itemId }) => dispatch => {
     dispatch(suppliersActions.fetch());
     dispatch(countriesActions.fetch());
     dispatch(employeesActions.fetch());
+    dispatch(cpcNumbersActions.fetch());
 };
 
 const mapDispatchToProps = {

--- a/src/Service.Host/client/src/containers/importBooks/tabs/OrderDetailsTab.js
+++ b/src/Service.Host/client/src/containers/importBooks/tabs/OrderDetailsTab.js
@@ -1,8 +1,7 @@
 import { connect } from 'react-redux';
 import { getItemError, initialiseOnMount } from '@linn-it/linn-form-components-library';
 import OrderDetailsTab from '../../../components/importBooks/tabs/OrderDetailsTab';
-import cpcNumbersActions from '../../../actions/impbookCpcNumbersActions';
-import cpcNumbersSelectors from '../../../selectors/impbookCpcNumbersSelectors';
+
 import rsnsActions from '../../../actions/rsnsActions';
 import rsnsSelectors from '../../../selectors/rsnsSelectors';
 import loansActions from '../../../actions/loansActions';
@@ -14,12 +13,6 @@ import postDutySelectors from '../../../selectors/postDutySelectors';
 import * as itemTypes from '../../../itemTypes';
 
 const mapStateToProps = state => ({
-    cpcNumbers: cpcNumbersSelectors.getItems(state)?.map(x => ({
-        displayText: `${x.cpcNumber === 13 ? `${x.cpcNumber} (IPR)` : x.cpcNumber} - ${
-            x.description
-        }`,
-        id: parseInt(x.cpcNumber, 10)
-    })),
     rsnsSearchResults: rsnsSelectors.getSearchItems(state).map?.(r => ({
         id: r.rsnNumber,
         name: r.rsnNumber.toString(),
@@ -48,12 +41,7 @@ const mapStateToProps = state => ({
     snackbarVisible: postDutySelectors.getSnackbarVisible(state)
 });
 
-const initialise = () => dispatch => {
-    dispatch(cpcNumbersActions.fetch());
-};
-
 const mapDispatchToProps = {
-    initialise,
     searchRsns: rsnsActions.search,
     clearRsnsSearch: rsnsActions.clearSearch,
     searchLoans: loansActions.search,


### PR DESCRIPTION
- Will now let Rhona save if weight mismatch -  if order details total weight doesn't match weight on front tab, save is now enabled but clicking it will bring up a new modal with a big warning that the weights don't match
- Moved cpc numbers to be loaded into the main impbook component instead of order details tab, so that I can print out the display text on the print component
- made page full width

Haven't had a chance to fix the conversion issue, will check the oracle form code and sort that separately tomorrow hopefully
