### PR TITLE
quick hack to stop the Add RSN button functionality stopping the expo…

### DIFF
--- a/src/Facade/Services/ExportRsnService.cs
+++ b/src/Facade/Services/ExportRsnService.cs
@@ -17,7 +17,8 @@
 
         public IEnumerable<ExportRsn> FindMatchingRSNs(IEnumerable<ExportRsn> rsns, string searchTerm)
         {
-            if (string.IsNullOrEmpty(searchTerm))
+            // fix for ticket 14895 search term coming in as null from Adam's export rsns lookup 
+            if ((string.IsNullOrEmpty(searchTerm)) || (searchTerm == "null"))
             {
                 return rsns;
             }


### PR DESCRIPTION
i made a change for Add RSN consignment that seems to have broken Add's original export lookup which Rhona needs

the call now adds searchTerm=null for the export RSNs search.  i need a quick hack to stop this while i figure a better Javascript one