### PR TITLE
Shipfiles fix

### DIFF
--- a/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
+++ b/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
@@ -185,7 +185,6 @@
                             pdfData.PackingList =
                                 this.packingListService.BuildPackingList(pdfData.PackingList).ToArray();
                             var body = this.BuildEmailBody(pdfData);
-
                             toSend.Add(new ConsignmentShipfileEmailModel
                             {
                                 PdfAttachment = pdfData,
@@ -203,6 +202,7 @@
                 }
                 else
                 {
+                    shipfile.Message = null;
                     toSend.AddRange(
                         outlets.Select(o =>
                         {

--- a/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
+++ b/src/Domain.LinnApps/ConsignmentShipfiles/ConsignmentShipfileService.cs
@@ -186,12 +186,12 @@
                                 this.packingListService.BuildPackingList(pdfData.PackingList).ToArray();
                             var body = this.BuildEmailBody(pdfData);
                             toSend.Add(new ConsignmentShipfileEmailModel
-                            {
-                                PdfAttachment = pdfData,
-                                ToCustomerName = account.ContactDetails.EmailAddress,
-                                ToEmailAddress = account.ContactDetails.EmailAddress,
-                                Body = body
-                            });
+                                           {
+                                               PdfAttachment = pdfData,
+                                               ToCustomerName = account.ContactDetails.EmailAddress,
+                                               ToEmailAddress = account.ContactDetails.EmailAddress,
+                                               Body = body
+                                           });
                         }
                     }
                     else

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailAndEmailAlreadySent.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingAnEmailAndEmailAlreadySent.cs
@@ -1,8 +1,6 @@
 ﻿namespace Linn.Stores.Domain.LinnApps.Tests.ConsignmentShipfileServiceTests
 {
-    using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
 
     using FluentAssertions;
 

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingShipfilesForEmailThatPreviouslyErrored.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingShipfilesForEmailThatPreviouslyErrored.cs
@@ -75,6 +75,7 @@
                 });
             this.result = this.Sut.SendEmails(this.toSend);
         }
+
         [Test]
         public void ShouldSendEmail()
         {
@@ -90,6 +91,7 @@
                 Arg.Any<Stream>(),
                 Arg.Any<string>());
         }
+
         [Test]
         public void ShouldUpdateStatusMessage()
         {

--- a/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingShipfilesForEmailThatPreviouslyErrored.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ConsignmentShipfileServiceTests/WhenSendingShipfilesForEmailThatPreviouslyErrored.cs
@@ -1,0 +1,100 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.ConsignmentShipfileServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Consignments;
+    using Linn.Stores.Domain.LinnApps.ConsignmentShipfiles;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenSendingShipfilesForEmailThatPreviouslyErrored : ContextBase
+    {
+        private ConsignmentShipfile toSend;
+
+        private ConsignmentShipfile result;
+
+        private ConsignmentShipfile shipfileData;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var account = new SalesAccount
+            {
+                OrgId = 1,
+                ContactId = 1,
+                ContactDetails = new Contact { EmailAddress = "customer@linn.co.uk", AddressId = 1 }
+            };
+            var orders = new List<SalesOrder>
+                              {
+                                  new SalesOrder
+                                      {
+                                          SalesOutlet = new SalesOutlet
+                                                            {
+                                                                OrderContact = new Contact
+                                                                                   {
+                                                                                       EmailAddress = "outlet1@linn.co.uk"
+                                                                                   }
+                                                            }
+                                      }
+                              };
+            var consignment = new Consignment
+            {
+                SalesAccount = account,
+                Items = new List<ConsignmentItem> { new ConsignmentItem { OrderNumber = 1 } },
+                Address = new Address { Country = new Country { CountryCode = "GB" } }
+            };
+            this.shipfileData = new ConsignmentShipfile
+            {
+                Id = 1,
+                Consignment = consignment,
+                Message = "Some Error Occurred"
+            };
+
+            this.toSend = new ConsignmentShipfile { Id = 1 };
+
+            this.ShipfileRepository.FindById(1).Returns(this.shipfileData);
+
+            this.PackingListService.BuildPackingList(Arg.Any<IEnumerable<PackingListItem>>())
+                .ReturnsForAnyArgs(new List<PackingListItem> { new PackingListItem(1, 1, "desc", 1m) });
+            this.SalesOrderRepository.FilterBy(Arg.Any<Expression<Func<SalesOrder, bool>>>()).Returns(orders.AsQueryable());
+            this.ConsignmentRepository.FindById(1).Returns(consignment);
+            this.DataService.GetPdfModelData(Arg.Any<int>(), Arg.Any<int>()).Returns(
+                new ConsignmentShipfilePdfModel
+                {
+                    DespatchNotes = new DespatchNote[] { new DespatchNote() },
+                    DateDispatched = "12/05/2008 09:34:58",
+                    ConsignmentNumber = "1"
+                });
+            this.result = this.Sut.SendEmails(this.toSend);
+        }
+        [Test]
+        public void ShouldSendEmail()
+        {
+            this.EmailService.Received().SendEmail(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                null,
+                null,
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                "Shipping Details",
+                Arg.Any<string>(),
+                Arg.Any<Stream>(),
+                Arg.Any<string>());
+        }
+        [Test]
+        public void ShouldUpdateStatusMessage()
+        {
+            this.result.Message.Should().Be(ShipfileStatusMessages.EmailSent);
+            this.result.ShipfileSent.Should().Be("Y");
+        }
+    }
+}


### PR DESCRIPTION
- fixes a bug where emails that previously errored (likely because of missing contact details) wouldn't send even if the error was fixed since they still had some error message against them
- fix is just to set the message to null if it gets past all the checks
