### PR TITLE
ipr report - only show 8 digits of tariff codes

### DIFF
--- a/tests/Unit/Domain.LinnApps.Tests/ImportBooksReportsServiceTests/WhenGettingIprExport.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ImportBooksReportsServiceTests/WhenGettingIprExport.cs
@@ -99,7 +99,7 @@
                                                           {
                                                               CpcNumber = this.iprCpcNumberId,
                                                               RsnNumber = 140333,
-                                                              TariffCode = "8495abc",
+                                                              TariffCode = "8495 12192",
                                                               LineNumber = 1,
                                                               Qty = 1,
                                                               OrderDescription = "potatoes"
@@ -151,7 +151,7 @@
             this.result.GetGridTextValue(this.result.RowIndex("123/3"), this.result.ColumnIndex("ShippingRef")).Should()
                 .Be("EdStob555");
             this.result.GetGridTextValue(this.result.RowIndex("123/3"), this.result.ColumnIndex("TariffCode")).Should()
-                .Be("849500001111");
+                .Be("8495 0000"); //should cut down to 8 digits with a space in middle
             this.result.GetGridTextValue(this.result.RowIndex("123/3"), this.result.ColumnIndex("OrderDescription"))
                 .Should().Be("carrots");
             this.result.GetGridTextValue(this.result.RowIndex("123/3"), this.result.ColumnIndex("Qty")).Should()

--- a/tests/Unit/Domain.LinnApps.Tests/ImportBooksReportsServiceTests/WhenGettingIprReport.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ImportBooksReportsServiceTests/WhenGettingIprReport.cs
@@ -44,7 +44,7 @@
                                                                      {
                                                                          CpcNumber = this.iprCpcNumberId,
                                                                          RsnNumber = 140111,
-                                                                         TariffCode = "849500001111",
+                                                                         TariffCode = " 8495 1234 11",
                                                                          LineNumber = 3,
                                                                          Qty = 1,
                                                                          OrderDescription = "carrots"
@@ -62,7 +62,7 @@
                                                                      {
                                                                          CpcNumber = 999999,
                                                                          RsnNumber = 140234,
-                                                                         TariffCode = "849500002222",
+                                                                         TariffCode = "84952222",
                                                                          LineNumber = 1,
                                                                          Qty = 1,
                                                                          OrderDescription = "garlic"
@@ -151,7 +151,7 @@
             this.result.GetGridTextValue(this.result.RowIndex("123/3"), this.result.ColumnIndex("ShippingRef")).Should()
                 .Be("EdStob555");
             this.result.GetGridTextValue(this.result.RowIndex("123/3"), this.result.ColumnIndex("TariffCode")).Should()
-                .Be("849500001111");
+                .Be("8495 1234"); //should cut down to 8 digits and remove whitespace from start
             this.result.GetGridTextValue(this.result.RowIndex("123/3"), this.result.ColumnIndex("OrderDescription"))
                 .Should().Be("carrots");
             this.result.GetGridTextValue(this.result.RowIndex("123/3"), this.result.ColumnIndex("Qty")).Should()


### PR DESCRIPTION
"Can I ask if you could amend the report to only show 8 digit tariff nos instead of 10? Customs had said it only needs 8 and I have to delete the last two digits.

Thanks
Yvonne"

http://rndsupport.linn.co.uk/scp/tickets.php?id=14986