### PR TITLE
HasExportReturn

### DIFF
--- a/src/Domain.LinnApps/Consignments/Consignment.cs
+++ b/src/Domain.LinnApps/Consignments/Consignment.cs
@@ -54,6 +54,8 @@
 
         public DateTime? CustomsEntryCodeDate { get; set; }
 
+        public string CarrierRef { get; set; }
+
         public IList<ConsignmentPallet> Pallets { get; set; }
 
         public IEnumerable<ExportBook> ExportBooks { get; set; }

--- a/src/Domain.LinnApps/ExportRsn.cs
+++ b/src/Domain.LinnApps/ExportRsn.cs
@@ -35,5 +35,9 @@
         public int? Depth { get; set; }
 
         public int? Width { get; set; }
+
+        public string RsnState { get; set; }
+
+        public string HasExportReturn { get; set; }
     }
 }

--- a/src/Facade/ResourceBuilders/ConsignmentResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/ConsignmentResourceBuilder.cs
@@ -35,6 +35,7 @@
                            CustomsEntryCodePrefix = consignment.CustomsEntryCodePrefix,
                            CustomsEntryCode = consignment.CustomsEntryCode,
                            CustomsEntryCodeDate = consignment.CustomsEntryCodeDate?.ToString("o"),
+                           CarrierRef = consignment.CarrierRef,
                            Pallets = consignment.Pallets?.Select(
                                pallet => new ConsignmentPalletResource
                                              {

--- a/src/Facade/Services/ExportRsnService.cs
+++ b/src/Facade/Services/ExportRsnService.cs
@@ -26,16 +26,16 @@
             return rsns.ToList().Where(r => r.RsnNumber.ToString().Contains(searchTerm));
         }
 
-        public IResult<IEnumerable<ExportRsn>> SearchRsns(int accountId, int? outletNumber, string searchTerm)
+        public IResult<IEnumerable<ExportRsn>> SearchRsns(int accountId, int? outletNumber, string searchTerm, string hasExportReturn)
         {
             if (outletNumber != null)
             {
                 return new SuccessResult<IEnumerable<ExportRsn>>(
-                    this.FindMatchingRSNs(this.repository.FilterBy(rsn => rsn.AccountId == accountId && rsn.OutletNumber == outletNumber), searchTerm));
+                    this.FindMatchingRSNs(this.repository.FilterBy(rsn => rsn.AccountId == accountId && rsn.OutletNumber == outletNumber && rsn.HasExportReturn == hasExportReturn), searchTerm));
             }
 
             return new SuccessResult<IEnumerable<ExportRsn>>(
-                this.FindMatchingRSNs(this.repository.FilterBy(rsn => rsn.AccountId == accountId),searchTerm));
+                this.FindMatchingRSNs(this.repository.FilterBy(rsn => rsn.AccountId == accountId && rsn.HasExportReturn == hasExportReturn),searchTerm));
         }
 
 

--- a/src/Facade/Services/IExportRsnService.cs
+++ b/src/Facade/Services/IExportRsnService.cs
@@ -7,6 +7,6 @@
 
     public interface IExportRsnService
     {
-        IResult<IEnumerable<ExportRsn>> SearchRsns(int accountId, int? outletNumber, string searchTerm);
+        IResult<IEnumerable<ExportRsn>> SearchRsns(int accountId, int? outletNumber, string searchTerm, string hasExportReturn);
     }
 }

--- a/src/Persistence.LinnApps/ServiceDbContext.cs
+++ b/src/Persistence.LinnApps/ServiceDbContext.cs
@@ -1397,6 +1397,8 @@
             q.Property(e => e.Height).HasColumnName("HEIGHT");
             q.Property(e => e.Depth).HasColumnName("DEPTH");
             q.Property(e => e.Width).HasColumnName("WIDTH");
+            q.Property(e => e.RsnState).HasColumnName("RSN_STATE").HasMaxLength(2);
+            q.Property(e => e.HasExportReturn).HasColumnName("HAS_EXPORT_RETURN").HasMaxLength(1);
         }
 
         private void QuerySalesAccounts(ModelBuilder builder)
@@ -1600,6 +1602,7 @@
             q.Property(c => c.CustomsEntryCodePrefix).HasColumnName("CUSTOMS_ENTRY_CODE_PREFIX").HasMaxLength(3);
             q.Property(c => c.CustomsEntryCode).HasColumnName("CUSTOMS_ENTRY_CODE").HasMaxLength(20);
             q.Property(c => c.CustomsEntryCodeDate).HasColumnName("CUSTOMS_ENTRY_CODE_DATE");
+            q.Property(c => c.CarrierRef).HasColumnName("CARRIER_REF").HasMaxLength(32);
             q.HasOne(c => c.ClosedBy).WithMany(m => m.ConsignmentClosedBy).HasForeignKey(s => s.ClosedById);
             q.HasMany(c => c.Pallets).WithOne().HasForeignKey(cp => cp.ConsignmentId);
             q.HasMany(c => c.Items).WithOne().HasForeignKey(ci => ci.ConsignmentId);

--- a/src/Resources/Consignments/ConsignmentResource.cs
+++ b/src/Resources/Consignments/ConsignmentResource.cs
@@ -42,6 +42,8 @@
 
         public string CustomsEntryCodeDate { get; set; }
 
+        public string CarrierRef { get; set; }
+
         public IEnumerable<ConsignmentPalletResource> Pallets { get; set; }
 
         public IEnumerable<ConsignmentItemResource> Items { get; set; }

--- a/src/Resources/RequestResources/ExportRsnSearchRequestResource.cs
+++ b/src/Resources/RequestResources/ExportRsnSearchRequestResource.cs
@@ -7,5 +7,7 @@
         public int? OutletNumber { get; set; }
 
         public string SearchTerm { get; set; }
+
+        public string HasExportReturn { get; set; }
     }
 }

--- a/src/Service.Host/client/src/components/consignments/Consignment.js
+++ b/src/Service.Host/client/src/components/consignments/Consignment.js
@@ -485,7 +485,8 @@ function Consignment({
                     depth: selectedRSN.depth,
                     width: selectedRSN.width,
                     weight: selectedRSN.weight,
-                    quantity: selectedRSN.quantity
+                    quantity: selectedRSN.quantity,
+                    itemTypeDisplay: 'Sealed Box'
                 });
             }
         }
@@ -1124,7 +1125,10 @@ function Consignment({
                                         items={rsnSearchResult()}
                                         placeholder="RSN Number"
                                         fetchItems={rsnNo =>
-                                            searchRsns(rsnNo, `&accountId=${item?.salesAccountId}`)
+                                            searchRsns(
+                                                rsnNo,
+                                                `&accountId=${item?.salesAccountId}&hasExportReturn=Y`
+                                            )
                                         }
                                         clearSearch={clearRsnsSearch}
                                         loading={rsnsSearchLoading}

--- a/src/Service.Host/client/src/components/consignments/Consignment.js
+++ b/src/Service.Host/client/src/components/consignments/Consignment.js
@@ -485,8 +485,7 @@ function Consignment({
                     depth: selectedRSN.depth,
                     width: selectedRSN.width,
                     weight: selectedRSN.weight,
-                    quantity: selectedRSN.quantity,
-                    itemTypeDisplay: 'Sealed Box'
+                    quantity: selectedRSN.quantity
                 });
             }
         }

--- a/src/Service.Host/client/src/components/exportReturns/ExportRsns.js
+++ b/src/Service.Host/client/src/components/exportReturns/ExportRsns.js
@@ -80,9 +80,12 @@ export default function ExportRsns({
     const handleSelectAccount = item => {
         dispatch({ type: 'selectAccount', payload: item });
         if (item.type === 'account') {
-            searchRsns(null, `&accountId=${item.accountId}`);
+            searchRsns(null, `&accountId=${item.accountId}&hasExportReturn=N`);
         } else {
-            searchRsns(null, `&accountId=${item.accountId}&outletNumber=${item.outletNumber}`);
+            searchRsns(
+                null,
+                `&accountId=${item.accountId}&outletNumber=${item.outletNumber}&hasExportReturn=N`
+            );
         }
     };
 

--- a/src/Service/Modules/ExportRsnModule.cs
+++ b/src/Service/Modules/ExportRsnModule.cs
@@ -21,7 +21,7 @@
         {
             var resource = this.Bind<ExportRsnSearchRequestResource>();
 
-            var results = this.exportRsnService.SearchRsns(resource.AccountId, resource.OutletNumber, resource.SearchTerm);
+            var results = this.exportRsnService.SearchRsns(resource.AccountId, resource.OutletNumber, resource.SearchTerm, resource.HasExportReturn);
 
             return this.Negotiate
                 .WithModel(results)

--- a/tests/Integration/Service.Tests/ExportRsnModuleSpecs/WhenGettingRsns.cs
+++ b/tests/Integration/Service.Tests/ExportRsnModuleSpecs/WhenGettingRsns.cs
@@ -24,7 +24,7 @@
             var rsn1 = new ExportRsn { RsnNumber = 1, AccountId = 123, OutletNumber = 1 };
             var rsn2 = new ExportRsn { RsnNumber = 2, AccountId = 123, OutletNumber = 1 };
 
-            this.ExportRsnService.SearchRsns(123, 1, "1")
+            this.ExportRsnService.SearchRsns(123, 1, "1","Y")
                 .Returns(new SuccessResult<IEnumerable<ExportRsn>>(new List<ExportRsn> { rsn1, rsn2 }));
 
             this.Response = this.Browser.Get(
@@ -35,6 +35,7 @@
                         with.Query("accountId", "123");
                         with.Query("outletNumber", "1");
                         with.Query("searchTerm", "1");
+                        with.Query("hasExportReturn", "Y");
                     }).Result;
         }
 
@@ -47,7 +48,7 @@
         [Test]
         public void ShouldCallService()
         {
-            this.ExportRsnService.Received().SearchRsns(123, 1, "1");
+            this.ExportRsnService.Received().SearchRsns(123, 1, "1","Y");
         }
 
         [Test]

--- a/tests/Unit/Facade.Tests/ExportRsnService/WhenGettingExportRsns.cs
+++ b/tests/Unit/Facade.Tests/ExportRsnService/WhenGettingExportRsns.cs
@@ -25,7 +25,7 @@
 
             this.ExportRsnRepository.FilterBy(Arg.Any<Expression<Func<ExportRsn, bool>>>()).Returns(rsns.AsQueryable());
 
-            this.result = this.Sut.SearchRsns(123, null, string.Empty);
+            this.result = this.Sut.SearchRsns(123, null, string.Empty, "Y");
         }
 
         [Test]

--- a/tests/Unit/Facade.Tests/ExportRsnService/WhenGettingExportRsnsWithNumber.cs
+++ b/tests/Unit/Facade.Tests/ExportRsnService/WhenGettingExportRsnsWithNumber.cs
@@ -25,7 +25,7 @@
 
             this.ExportRsnRepository.FilterBy(Arg.Any<Expression<Func<ExportRsn, bool>>>()).Returns(rsns.AsQueryable());
 
-            this.result = this.Sut.SearchRsns(123, null, "2","Y");
+            this.result = this.Sut.SearchRsns(123, null, "2", "Y");
         }
 
         [Test]

--- a/tests/Unit/Facade.Tests/ExportRsnService/WhenGettingExportRsnsWithNumber.cs
+++ b/tests/Unit/Facade.Tests/ExportRsnService/WhenGettingExportRsnsWithNumber.cs
@@ -25,7 +25,7 @@
 
             this.ExportRsnRepository.FilterBy(Arg.Any<Expression<Func<ExportRsn, bool>>>()).Returns(rsns.AsQueryable());
 
-            this.result = this.Sut.SearchRsns(123, null, "2");
+            this.result = this.Sut.SearchRsns(123, null, "2","Y");
         }
 
         [Test]


### PR DESCRIPTION
Export_RSNS_view now serves both making an export return and adding an RSN to a consignment

there is a new flag on the view to show if a RSN is already in an export return.  If it is it shouldn't be allowed to be added to another export return but it can go on a consignment.  If it isn't it should be allowed on an export return but can't go on a consignment.

There is also a small change to add carrier ref to consignments 

