### PR TITLE
add carrier ref p2

### DIFF
--- a/src/Domain.LinnApps/Consignments/Consignment.cs
+++ b/src/Domain.LinnApps/Consignments/Consignment.cs
@@ -56,6 +56,8 @@
 
         public string CarrierRef { get; set; }
 
+        public string MasterCarrierRef { get; set; }
+
         public IList<ConsignmentPallet> Pallets { get; set; }
 
         public IEnumerable<ExportBook> ExportBooks { get; set; }

--- a/src/Facade/ResourceBuilders/ConsignmentResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/ConsignmentResourceBuilder.cs
@@ -36,6 +36,7 @@
                            CustomsEntryCode = consignment.CustomsEntryCode,
                            CustomsEntryCodeDate = consignment.CustomsEntryCodeDate?.ToString("o"),
                            CarrierRef = consignment.CarrierRef,
+                           MasterCarrierRef = consignment.MasterCarrierRef,
                            Pallets = consignment.Pallets?.Select(
                                pallet => new ConsignmentPalletResource
                                              {

--- a/src/Facade/Services/ConsignmentFacadeService.cs
+++ b/src/Facade/Services/ConsignmentFacadeService.cs
@@ -90,6 +90,8 @@
                 entity.CustomsEntryCodeDate = string.IsNullOrEmpty(updateResource.CustomsEntryCodeDate)
                                                   ? (DateTime?)null
                                                   : DateTime.Parse(updateResource.CustomsEntryCodeDate);
+                entity.CarrierRef = updateResource.CarrierRef;
+                entity.MasterCarrierRef = updateResource.MasterCarrierRef;
 
                 this.UpdatePallets(entity, updateResource.Pallets.ToList());
                 this.UpdateItems(entity, updateResource.Items.ToList());

--- a/src/Persistence.LinnApps/ServiceDbContext.cs
+++ b/src/Persistence.LinnApps/ServiceDbContext.cs
@@ -1603,6 +1603,7 @@
             q.Property(c => c.CustomsEntryCode).HasColumnName("CUSTOMS_ENTRY_CODE").HasMaxLength(20);
             q.Property(c => c.CustomsEntryCodeDate).HasColumnName("CUSTOMS_ENTRY_CODE_DATE");
             q.Property(c => c.CarrierRef).HasColumnName("CARRIER_REF").HasMaxLength(32);
+            q.Property(c => c.MasterCarrierRef).HasColumnName("MASTER_CARRIER_REF").HasMaxLength(32);
             q.HasOne(c => c.ClosedBy).WithMany(m => m.ConsignmentClosedBy).HasForeignKey(s => s.ClosedById);
             q.HasMany(c => c.Pallets).WithOne().HasForeignKey(cp => cp.ConsignmentId);
             q.HasMany(c => c.Items).WithOne().HasForeignKey(ci => ci.ConsignmentId);

--- a/src/Resources/Consignments/ConsignmentResource.cs
+++ b/src/Resources/Consignments/ConsignmentResource.cs
@@ -44,6 +44,8 @@
 
         public string CarrierRef { get; set; }
 
+        public string MasterCarrierRef { get; set; }
+
         public IEnumerable<ConsignmentPalletResource> Pallets { get; set; }
 
         public IEnumerable<ConsignmentItemResource> Items { get; set; }

--- a/src/Resources/Consignments/ConsignmentUpdateResource.cs
+++ b/src/Resources/Consignments/ConsignmentUpdateResource.cs
@@ -20,6 +20,10 @@
 
         public string CustomsEntryCodeDate { get; set; }
 
+        public string CarrierRef { get; set; }
+
+        public string MasterCarrierRef { get; set; }
+
         public IEnumerable<ConsignmentPalletResource> Pallets { get; set; } = new List<ConsignmentPalletResource>();
 
         public IEnumerable<ConsignmentItemResource> Items { get; set; } = new List<ConsignmentItemResource>();

--- a/src/Service.Host/client/src/components/consignments/DetailsItemsTab.js
+++ b/src/Service.Host/client/src/components/consignments/DetailsItemsTab.js
@@ -1023,6 +1023,40 @@ function DetailsItemsTab({
                                 />
                             </TableCell>
                         </TableRow>
+                        <TableRow key="CarrierRef">
+                            <TablePromptItem text="Carrier Refs" />
+                            <TableCell className={classes.tableCell}>
+                                {viewMode ? (
+                                    `${showText(consignment.carrierRef)}`
+                                ) : (
+                                    <>
+                                        <InputField
+                                            placeholder="Carrier Ref"
+                                            propertyName="carrierRef"
+                                            value={consignment.carrierRef}
+                                            onChange={updateField}
+                                            maxLength={32}
+                                        />
+                                    </>
+                                )}
+                            </TableCell>
+                            <TablePromptItem text="Master Ref" />
+                            <TableCell className={classes.tableCell}>
+                                {viewMode ? (
+                                    `${showText(consignment.masterCarrierRef)}`
+                                ) : (
+                                    <>
+                                        <InputField
+                                            placeholder="Master Carrier Ref"
+                                            propertyName="masterCarrierRef"
+                                            value={consignment.masterCarrierRef}
+                                            onChange={updateField}
+                                            maxLength={32}
+                                        />
+                                    </>
+                                )}
+                            </TableCell>
+                        </TableRow>
                         <TableRow key="CustomsEntry">
                             <TablePromptItem text="Customs Entry Code" />
                             <TableCell className={classes.tableCell}>
@@ -1594,6 +1628,8 @@ DetailsItemsTab.propTypes = {
         terms: PropTypes.string,
         status: PropTypes.string,
         hubId: PropTypes.number,
+        carrierRef: PropTypes.string,
+        masterCarrierRef: PropTypes.string,
         customsEntryCodePrefix: PropTypes.string,
         customsEntryCode: PropTypes.string,
         customsEntryCodeDate: PropTypes.string,


### PR DESCRIPTION
add carrier ref and master carrier ref to the consignment

master carrier ref only really exists for the EU where they have a carrier ref from the master shipping bill for all the shipments that go out together to the hub and then the carrier ref is for the final leg from the hub to the customer

at the moment they can edit on the consignment screen but might do a more sophisticated batch edit in the future