### PR TITLE
Consignment Export Edit

### DIFF
--- a/src/Facade/Services/ConsignmentFacadeService.cs
+++ b/src/Facade/Services/ConsignmentFacadeService.cs
@@ -227,7 +227,6 @@
                 var fromDate = DateTime.Parse(resource.From);
                 var toDate = DateTime.Parse(resource.To);
 
-
                 if (resource.HubId == null)
                 {
                     return new SuccessResult<IEnumerable<Consignment>>(this.repository.FilterBy(c => c.DateClosed >= fromDate && c.DateClosed <= toDate));

--- a/src/Facade/Services/ConsignmentFacadeService.cs
+++ b/src/Facade/Services/ConsignmentFacadeService.cs
@@ -11,12 +11,15 @@
     using Linn.Stores.Domain.LinnApps.Consignments;
     using Linn.Stores.Domain.LinnApps.Exceptions;
     using Linn.Stores.Resources.Consignments;
+    using Linn.Stores.Resources.RequestResources;
 
-    public class ConsignmentFacadeService : FacadeService<Consignment, int, ConsignmentResource, ConsignmentUpdateResource>
+    public class ConsignmentFacadeService : FacadeService<Consignment, int, ConsignmentResource, ConsignmentUpdateResource>, IConsignmentFacadeService
     {
         private readonly IConsignmentService consignmentService;
 
         private readonly IDatabaseService databaseService;
+
+        private readonly IRepository<Consignment, int> repository;
 
         public ConsignmentFacadeService(
             IRepository<Consignment, int> repository,
@@ -27,6 +30,7 @@
         {
             this.consignmentService = consignmentService;
             this.databaseService = databaseService;
+            this.repository = repository;
         }
 
         protected override Consignment CreateFromResource(ConsignmentResource resource)
@@ -62,21 +66,31 @@
         {
             if (updateResource.Status == "C")
             {
-                if (entity.Status != "L")
+                if (entity.Status == "L")
                 {
-                    throw new ConsignmentEditException($"You cannot edit closed consignment {entity.ConsignmentId}.");
+                    if (!updateResource.ClosedById.HasValue)
+                    {
+                        throw new ConsignmentCloseException("Closed by id must be provided to close consignment");
+                    }
+
+                    this.consignmentService.CloseConsignment(entity, updateResource.ClosedById.Value);
+
+                    entity.ClosedById = updateResource.ClosedById;
+                    entity.Status = "C";
+                    entity.DateClosed = DateTime.Now;
+                }
+                else
+                {
+                    // only update customs fields
+                    entity.CustomsEntryCodePrefix = updateResource.CustomsEntryCodePrefix;
+                    entity.CustomsEntryCode = updateResource.CustomsEntryCode;
+                    entity.CustomsEntryCodeDate = string.IsNullOrEmpty(updateResource.CustomsEntryCodeDate)
+                                                      ? (DateTime?)null
+                                                      : DateTime.Parse(updateResource.CustomsEntryCodeDate);
+                    entity.CarrierRef = updateResource.CarrierRef;
+                    entity.MasterCarrierRef = updateResource.MasterCarrierRef;
                 }
 
-                if (!updateResource.ClosedById.HasValue)
-                {
-                    throw new ConsignmentCloseException("Closed by id must be provided to close consignment");
-                }
-
-                this.consignmentService.CloseConsignment(entity, updateResource.ClosedById.Value);
-
-                entity.ClosedById = updateResource.ClosedById;
-                entity.Status = "C";
-                entity.DateClosed = DateTime.Now;
             }
             else
             {
@@ -199,6 +213,32 @@
                     entity.Items.RemoveAt(entity.Items.IndexOf(removedItem));
                 }
             }
+        }
+
+        public IResult<IEnumerable<Consignment>> GetByRequestResource(ConsignmentsRequestResource resource)
+        {
+            if (!string.IsNullOrEmpty(resource.From))
+            {
+                if (string.IsNullOrEmpty(resource.To))
+                {
+                    return new BadRequestResult<IEnumerable<Consignment>>("No To Date specified");
+                }
+
+                var fromDate = DateTime.Parse(resource.From);
+                var toDate = DateTime.Parse(resource.To);
+
+
+                if (resource.HubId == null)
+                {
+                    return new SuccessResult<IEnumerable<Consignment>>(this.repository.FilterBy(c => c.DateClosed >= fromDate && c.DateClosed <= toDate));
+                }
+                else
+                {
+                    return new SuccessResult<IEnumerable<Consignment>>(this.repository.FilterBy(c => c.DateClosed >= fromDate && c.DateClosed <= toDate && c.HubId == resource.HubId));
+                }
+            }
+
+            return this.GetAll();
         }
     }
 }

--- a/src/Facade/Services/IConsignmentFacadeService.cs
+++ b/src/Facade/Services/IConsignmentFacadeService.cs
@@ -1,0 +1,13 @@
+﻿namespace Linn.Stores.Facade.Services
+{
+    using Linn.Common.Facade;
+    using Linn.Stores.Domain.LinnApps.Consignments;
+    using Linn.Stores.Resources.Consignments;
+    using Linn.Stores.Resources.RequestResources;
+    using System.Collections.Generic;
+
+    public interface IConsignmentFacadeService : IFacadeService<Consignment, int, ConsignmentResource, ConsignmentUpdateResource>
+    {
+        IResult<IEnumerable<Consignment>> GetByRequestResource(ConsignmentsRequestResource resource);
+    }
+}

--- a/src/IoC/ServiceModule.cs
+++ b/src/IoC/ServiceModule.cs
@@ -162,7 +162,7 @@
             builder.RegisterType<TqmsMasterFacadeService>().As<ISingleRecordFacadeService<TqmsMaster, TqmsMasterResource>>();
             builder.RegisterType<TqmsJobrefsFacadeService>().As<IFacadeService<TqmsJobRef, string, TqmsJobRefResource, TqmsJobRefResource>>();
             builder.RegisterType<ConsignmentShipfileFacadeService>().As<IConsignmentShipfileFacadeService>();
-            builder.RegisterType<ConsignmentFacadeService>().As<IFacadeService<Consignment, int, ConsignmentResource, ConsignmentUpdateResource>>();
+            builder.RegisterType<ConsignmentFacadeService>().As<IConsignmentFacadeService>();
             builder.RegisterType<CurrencyFacadeService>()
                 .As<IFacadeService<Currency, string, CurrencyResource, CurrencyResource>>();
             builder.RegisterType<HubFacadeService>().As<IFacadeService<Hub, int, HubResource, HubResource>>();

--- a/src/Resources/RequestResources/ConsignmentsRequestResource.cs
+++ b/src/Resources/RequestResources/ConsignmentsRequestResource.cs
@@ -1,0 +1,11 @@
+﻿namespace Linn.Stores.Resources.RequestResources
+{
+    public class ConsignmentsRequestResource : FromToDateResource
+    {
+        public string searchTerm { get; set; }
+
+        public int? ConsignmentId { get; set; }
+
+        public int? HubId { get; set; }
+    }
+}

--- a/src/Service.Host/client/src/components/Root.js
+++ b/src/Service.Host/client/src/components/Root.js
@@ -45,6 +45,7 @@ import TqmsSummaryByCategoryReportOptions from '../containers/reports/TqmsSummar
 import TqmsSummaryByCategoryReport from '../containers/reports/TqmsSummaryByCategoryReport';
 import ConsignmentShipfiles from '../containers/ConsignmentShipfiles';
 import Consignment from '../containers/consignments/Consignment';
+import ExportConsignments from '../containers/consignments/ExportConsignments';
 import GoodsInUtility from '../containers/goodsIn/GoodsInUtility';
 import ImportBook from '../containers/importBooks/ImportBook';
 import ImportBooks from '../containers/importBooks/ImportBooks';
@@ -280,6 +281,11 @@ const Root = ({ store }) => (
                                         exact
                                         path="/logistics/consignments/:consignmentId"
                                         component={Consignment}
+                                    />
+                                    <Route
+                                        exact
+                                        path="/logistics/exports/consignments"
+                                        component={ExportConsignments}
                                     />
                                     <Route
                                         exact

--- a/src/Service.Host/client/src/components/__tests__/consignments/exportConsignments.test.js
+++ b/src/Service.Host/client/src/components/__tests__/consignments/exportConsignments.test.js
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jest-environment-jsdom-sixteen
+ */
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import render from '../../../test-utils';
+import ExportConsignments from '../../consignments/ExportConsignments';
+
+const hubs = [
+    {
+        hubId: 1,
+        description: 'Hubby McHubFace'
+    }
+]
+
+const items = [
+    {
+        consignmentId: 1,
+        customerName: 'Euro Hifi',
+        carrier: 'DHL',
+        carrierRef: null,
+        masterCarrierRef: null,
+        customsEntryCodePrefix: null,
+        customsEntryCode: null,
+        customsEntryCodeDate: null
+    },
+    {
+        consignmentId: 2,
+        customerName: 'Audio Berlin',
+        carrier: 'DHL',
+        carrierRef: null,
+        masterCarrierRef: null,
+        customsEntryCodePrefix: null,
+        customsEntryCode: null,
+        customsEntryCodeDate: null
+    },
+    {
+        consignmentId: 3,
+        customerName: 'Studio Riga',
+        carrier: 'DHL',
+        carrierRef: null,
+        masterCarrierRef: null,
+        customsEntryCodePrefix: null,
+        customsEntryCode: null,
+        customsEntryCodeDate: null
+    }
+];
+
+const searchConsignments = jest.fn();
+const updateConsignment = jest.fn();
+
+test('Before search button pressed', () => {
+    const { getByText, queryByText } = render(
+        <ExportConsignments
+            hubs={hubs}
+            hubsLoading={false}
+            options={null}
+            requestErrors={null}
+            loading={false}
+            consignments={[]}
+            searchConsignments={searchConsignments}
+            updateConsignment={updateConsignment}
+        />
+    );
+    expect(getByText('From Date')).toBeInTheDocument();
+    expect(getByText('To Date')).toBeInTheDocument();
+    expect(getByText('No Consignments')).toBeInTheDocument();
+    expect(queryByText('Master Carrier Ref')).toBeNull();
+});
+
+test('With Search Results', () => {
+    const { getByText, queryByText } = render(
+        <ExportConsignments
+            hubs={hubs}
+            hubsLoading={false}
+            options={null}
+            requestErrors={null}
+            loading={false}
+            consignments={items}
+            searchConsignments={searchConsignments}
+            updateConsignment={updateConsignment}
+        />
+    );
+    expect(getByText('From Date')).toBeInTheDocument();
+    expect(getByText('To Date')).toBeInTheDocument();
+    expect(queryByText('No Consignments')).toBeNull();
+    expect(getByText('Master Carrier Ref')).toBeInTheDocument();
+});

--- a/src/Service.Host/client/src/components/consignments/Consignment.js
+++ b/src/Service.Host/client/src/components/consignments/Consignment.js
@@ -7,7 +7,8 @@ import {
     utilities,
     ErrorCard,
     InputField,
-    Typeahead
+    Typeahead,
+    LinkButton
 } from '@linn-it/linn-form-components-library';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
@@ -690,6 +691,9 @@ function Consignment({
                                     >
                                         Show Consignment
                                     </Button>
+                                </Grid>
+                                <Grid item xs={12}>
+                                    <LinkButton to="exports/consignments" text="Export Details" />
                                 </Grid>
                             </>
                         )}

--- a/src/Service.Host/client/src/components/consignments/Consignment.js
+++ b/src/Service.Host/client/src/components/consignments/Consignment.js
@@ -693,7 +693,10 @@ function Consignment({
                                     </Button>
                                 </Grid>
                                 <Grid item xs={12}>
-                                    <LinkButton to="exports/consignments" text="Export Details" />
+                                    <LinkButton
+                                        to="exports/consignments"
+                                        text="Consignments Export Details"
+                                    />
                                 </Grid>
                             </>
                         )}

--- a/src/Service.Host/client/src/components/consignments/ExportConsignments.js
+++ b/src/Service.Host/client/src/components/consignments/ExportConsignments.js
@@ -28,9 +28,9 @@ function ExportConsignments({
     const defaultStartDate = new Date();
     defaultStartDate.setDate(defaultStartDate.getDate() - 1);
     const [fromDate, setFromDate] = useState(
-        options.fromDate ? new Date(options.fromDate) : defaultStartDate
+        options?.fromDate ? new Date(options.fromDate) : defaultStartDate
     );
-    const [toDate, setToDate] = useState(options.toDate ? new Date(options.toDate) : new Date());
+    const [toDate, setToDate] = useState(options?.toDate ? new Date(options.toDate) : new Date());
     const [hubId, setHubId] = useState(null);
     const [newMasterCarrierRef, setNewMasterCarrierRef] = useState(null);
     const [rows, setRows] = useState([]);

--- a/src/Service.Host/client/src/components/consignments/ExportConsignments.js
+++ b/src/Service.Host/client/src/components/consignments/ExportConsignments.js
@@ -1,0 +1,249 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import moment from 'moment';
+import {
+    Loading,
+    DatePicker,
+    utilities,
+    Dropdown,
+    SaveBackCancelButtons,
+    Title
+} from '@linn-it/linn-form-components-library';
+import Grid from '@material-ui/core/Grid';
+import { DataGrid } from '@mui/x-data-grid';
+import PropTypes from 'prop-types';
+import Button from '@material-ui/core/Button';
+import Page from '../../containers/Page';
+
+function ExportConsignments({
+    hubs,
+    hubsLoading,
+    options,
+    requestErrors,
+    loading,
+    consignments,
+    searchConsignments,
+    updateConsignment
+}) {
+    const defaultStartDate = new Date();
+    defaultStartDate.setDate(defaultStartDate.getDate() - 1);
+    const [fromDate, setFromDate] = useState(
+        options.fromDate ? new Date(options.fromDate) : defaultStartDate
+    );
+    const [toDate, setToDate] = useState(options.toDate ? new Date(options.toDate) : new Date());
+    const [hubId, setHubId] = useState(null);
+    const [rows, setRows] = useState([]);
+    const [editing, setEditing] = useState(false);
+
+    const hubOptions = () => {
+        return utilities.sortEntityList(hubs, 'hubId')?.map(h => ({
+            id: h.hubId,
+            displayText: `${h.hubId} - ${h.description}`
+        }));
+    };
+
+    const updateField = (fieldName, newValue) => {
+        if (fieldName === 'hubId') {
+            setHubId(newValue);
+        }
+    };
+
+    const findConsignments = () => {
+        const searchTerm = options.consignmentId ? options.consignmentId : null;
+        searchConsignments(
+            searchTerm,
+            `&from=${moment(fromDate).format('DD-MMM-YYYY')}&to=${moment(toDate).format(
+                'DD-MMM-YYYY'
+            )}`
+        );
+    };
+
+    useEffect(() => {
+        setRows(
+            consignments.map(c => ({
+                ...c,
+                id: c.consignmentId
+            }))
+        );
+    }, [consignments]);
+
+    const handleSave = () => {
+        rows.forEach(a => {
+            if (a.updating) {
+                updateConsignment(a.id, a);
+            }
+        });
+
+        setEditing(false);
+    };
+
+    const handleCancel = () => {
+        setRows(
+            consignments.map(c => ({
+                ...c,
+                id: c.consignmentId
+            }))
+        );
+        setEditing(false);
+    };
+
+    const columns = [
+        { field: 'id', headerName: 'Cons Id', width: 150, disableColumnMenu: true },
+        { field: 'customerName', headerName: 'Customer Name', width: 300 },
+        { field: 'carrier', headerName: 'Carrier', width: 100 },
+        { field: 'masterCarrierRef', headerName: 'Master Carrier Ref', editable: true, width: 250 },
+        { field: 'carrierRef', headerName: 'Carrier Ref', editable: true, width: 250 },
+        {
+            field: 'customsEntryCodePrefix',
+            headerName: 'Customs Entry Prefix',
+            width: 100,
+            editable: true,
+            disableColumnMenu: true
+        },
+        {
+            field: 'customsEntryCode',
+            headerName: 'Code',
+            width: 100,
+            editable: true,
+            disableColumnMenu: true
+        },
+        {
+            field: 'customsEntryCodeDate',
+            headerName: 'Date',
+            width: 100,
+            editable: true,
+            disableColumnMenu: true
+        }
+    ];
+
+    const updateRow = useCallback(
+        (rowId, fieldName, newValue) => {
+            const newRows = rows.map(r =>
+                r.consignmentId === rowId
+                    ? {
+                          ...r,
+                          [fieldName]: newValue,
+                          updating: true
+                      }
+                    : r
+            );
+            setRows(newRows);
+        },
+        [rows]
+    );
+
+    const handleEditRowsModelChange = useCallback(
+        model => {
+            if (model && Object.keys(model)[0]) {
+                setEditing(true);
+                const key = parseInt(Object.keys(model)[0], 10);
+                const key2 = Object.keys(model[key])[0];
+                if (model && model[key] && model[key][key2] && model[key][key2].value) {
+                    updateRow(key, key2, model[key][key2].value);
+                }
+            }
+        },
+        [updateRow]
+    );
+
+    return (
+        <div className="pageContainer">
+            <Page requestErrors={requestErrors} showRequestErrors width="xl">
+                <Title text="Consignment Export Details" />
+                <Grid container spacing={3} style={{ paddingTop: '30px' }}>
+                    <Grid item xs={3}>
+                        <DatePicker
+                            label="From Date"
+                            value={fromDate.toString()}
+                            onChange={setFromDate}
+                        />
+                    </Grid>
+                    <Grid item xs={3}>
+                        <DatePicker
+                            label="To Date"
+                            value={toDate.toString()}
+                            minDate={fromDate.toString()}
+                            onChange={setToDate}
+                        />
+                    </Grid>
+                    <Grid item xs={3}>
+                        <Dropdown
+                            propertyName="hubId"
+                            label="Hub"
+                            items={hubOptions()}
+                            onChange={updateField}
+                            value={hubId}
+                            optionsLoading={hubsLoading}
+                        />
+                    </Grid>
+                    <Grid item xs={3}>
+                        <Button
+                            onClick={() => findConsignments()}
+                            variant="outlined"
+                            color="primary"
+                        >
+                            Search
+                        </Button>
+                    </Grid>
+                </Grid>
+                <Grid container spacing={3} style={{ paddingTop: '30px' }}>
+                    {loading ? (
+                        <Loading />
+                    ) : (
+                        <>
+                            {consignments?.length > 0 ? (
+                                <>
+                                    <DataGrid
+                                        rows={rows}
+                                        columns={columns}
+                                        onEditRowsModelChange={handleEditRowsModelChange}
+                                        density="compact"
+                                        autoHeight
+                                        hideFooter
+                                    />
+                                    <SaveBackCancelButtons
+                                        saveDisabled={!editing}
+                                        saveClick={handleSave}
+                                        cancelClick={handleCancel}
+                                        backClick={handleCancel}
+                                    />
+                                </>
+                            ) : (
+                                <>No Consignments</>
+                            )}
+                        </>
+                    )}
+                </Grid>
+            </Page>
+        </div>
+    );
+}
+
+ExportConsignments.propTypes = {
+    hubs: PropTypes.arrayOf(
+        PropTypes.shape({ hubId: PropTypes.number, description: PropTypes.string })
+    ),
+    hubsLoading: PropTypes.bool,
+    options: PropTypes.shape({
+        fromDate: PropTypes.string,
+        toDate: PropTypes.string,
+        consignmentId: PropTypes.string
+    }),
+    requestErrors: PropTypes.arrayOf(
+        PropTypes.shape({ message: PropTypes.string, name: PropTypes.string })
+    ),
+    searchConsignments: PropTypes.func.isRequired,
+    updateConsignments: PropTypes.func.isRequired,
+    loading: PropTypes.bool,
+    consignments: PropTypes.arrayOf(PropTypes.shape({}))
+};
+
+ExportConsignments.defaultProps = {
+    hubs: [],
+    hubsLoading: false,
+    options: null,
+    requestErrors: null,
+    consignments: [],
+    loading: false
+};
+
+export default ExportConsignments;

--- a/src/Service.Host/client/src/components/consignments/ExportConsignments.js
+++ b/src/Service.Host/client/src/components/consignments/ExportConsignments.js
@@ -32,9 +32,8 @@ function ExportConsignments({
     );
     const [toDate, setToDate] = useState(options.toDate ? new Date(options.toDate) : new Date());
     const [hubId, setHubId] = useState(null);
-    const [masterCarrierRef, setMasterCarrierRef] = useState(null);
+    const [newMasterCarrierRef, setNewMasterCarrierRef] = useState(null);
     const [rows, setRows] = useState([]);
-    const [selectedRows, setSelectedRows] = useState([]);
     const [editing, setEditing] = useState(false);
 
     const hubOptions = () => {
@@ -67,10 +66,6 @@ function ExportConsignments({
                 )}`
             );
         }
-    };
-
-    const handleSelectRow = selected => {
-        setSelectedRows(rows.filter(r => selected.includes(r.id)));
     };
 
     useEffect(() => {
@@ -134,26 +129,47 @@ function ExportConsignments({
 
     const updateRow = useCallback(
         (rowId, fieldName, newValue) => {
-            setRows(rows =>
-                rows.map(r =>
-                    r.consignmentId === rowId
-                        ? {
-                              ...r,
-                              [fieldName]: newValue,
-                              updating: true
-                          }
-                        : r
-                )
+            const newRows = rows.map(r =>
+                r.consignmentId === rowId
+                    ? {
+                          ...r,
+                          [fieldName]: newValue,
+                          updating: true
+                      }
+                    : r
             );
+            setRows(newRows);
         },
         [rows]
     );
 
-    const multiSetMCarrierRef = () => {
-        if (selectedRows) {
-            selectedRows.forEach(r => updateRow(r.id, 'masterCarrierRef', masterCarrierRef));
-            setEditing(true);
-        }
+    const handleSelectRow = selected => {
+        const newRows = rows.map(r =>
+            selected.includes(r.id)
+                ? {
+                      ...r,
+                      selected: true
+                  }
+                : {
+                      ...r,
+                      selected: false
+                  }
+        );
+        setRows(newRows);
+    };
+
+    const setMultiMasterCarrierRef = () => {
+        const newRows = rows.map(r =>
+            r.selected
+                ? {
+                      ...r,
+                      masterCarrierRef: newMasterCarrierRef,
+                      updating: true
+                  }
+                : r
+        );
+        setRows(newRows);
+        setEditing(true);
     };
 
     const handleEditRowsModelChange = useCallback(
@@ -225,12 +241,14 @@ function ExportConsignments({
                                                     label="Master Carrier Ref"
                                                     placeholder="Master Carrier Ref"
                                                     propertyName="consignmentIdSelect"
-                                                    value={masterCarrierRef}
-                                                    onChange={(_, val) => setMasterCarrierRef(val)}
+                                                    value={newMasterCarrierRef}
+                                                    onChange={(_, val) =>
+                                                        setNewMasterCarrierRef(val)
+                                                    }
                                                 />
                                                 <Button
                                                     style={{ marginTop: '10px' }}
-                                                    onClick={() => multiSetMCarrierRef()}
+                                                    onClick={() => setMultiMasterCarrierRef()}
                                                     variant="outlined"
                                                     color="primary"
                                                 >

--- a/src/Service.Host/client/src/containers/consignments/ExportConsignments.js
+++ b/src/Service.Host/client/src/containers/consignments/ExportConsignments.js
@@ -1,0 +1,35 @@
+import { connect } from 'react-redux';
+import { initialiseOnMount, getRequestErrors } from '@linn-it/linn-form-components-library';
+import queryString from 'query-string';
+import ExportConsignments from '../../components/consignments/ExportConsignments';
+import consignmentsSelectors from '../../selectors/consignmentsSelectors';
+import consignmentsActions from '../../actions/consignmentsActions';
+import consignmentActions from '../../actions/consignmentActions';
+import hubsSelectors from '../../selectors/hubsSelectors';
+import hubsActions from '../../actions/hubsActions';
+
+const getOptions = ownProps => {
+    const options = queryString.parse(ownProps.location.search);
+    return options || {};
+};
+
+const mapStateToProps = (state, ownProps) => ({
+    hubs: hubsSelectors.getItems(state),
+    hubsLoading: hubsSelectors.getLoading(state),
+    options: getOptions(ownProps),
+    requestErrors: getRequestErrors(state)?.filter(error => error.type !== 'FETCH_ERROR'),
+    loading: consignmentsSelectors.getSearchLoading(state),
+    consignments: consignmentsSelectors.getSearchItems(state)
+});
+
+const initialise = ({ options }) => dispatch => {
+    dispatch(hubsActions.fetch());
+};
+
+const mapDispatchToProps = {
+    initialise,
+    searchConsignments: consignmentsActions.searchWithOptions,
+    updateConsignment: consignmentActions.update
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(initialiseOnMount(ExportConsignments));

--- a/src/Service/Modules/ConsignmentsModule.cs
+++ b/src/Service/Modules/ConsignmentsModule.cs
@@ -16,7 +16,7 @@
 
     public sealed class ConsignmentsModule : NancyModule
     {
-        private readonly IFacadeService<Consignment, int, ConsignmentResource, ConsignmentUpdateResource> consignmentFacadeService;
+        private readonly IConsignmentFacadeService consignmentFacadeService;
 
         private readonly IFacadeService<Hub, int, HubResource, HubResource> hubFacadeService;
 
@@ -31,7 +31,7 @@
         private readonly ILogisticsReportsFacadeService logisticsReportsFacadeService;
 
         public ConsignmentsModule(
-            IFacadeService<Consignment, int, ConsignmentResource, ConsignmentUpdateResource> consignmentFacadeService,
+            IConsignmentFacadeService consignmentFacadeService,
             IFacadeService<Hub, int, HubResource, HubResource> hubFacadeService,
             IFacadeService<Carrier, string, CarrierResource, CarrierResource> carrierFacadeService,
             IFacadeService<ShippingTerm, int, ShippingTermResource, ShippingTermResource> shippingTermFacadeService,
@@ -190,8 +190,10 @@
 
         private object GetConsignments()
         {
+            var resource = this.Bind<ConsignmentsRequestResource>();
+
             return this.Negotiate
-                .WithModel(this.consignmentFacadeService.GetAll())
+                .WithModel(this.consignmentFacadeService.GetByRequestResource(resource))
                 .WithMediaRangeModel("text/html", ApplicationSettings.Get)
                 .WithView("Index");
         }

--- a/tests/Integration/Service.Tests/ConsignmentModuleSpecs/ContextBase.cs
+++ b/tests/Integration/Service.Tests/ConsignmentModuleSpecs/ContextBase.cs
@@ -22,7 +22,7 @@
 
     public abstract class ContextBase : NancyContextBase
     {
-        protected IFacadeService<Consignment, int, ConsignmentResource, ConsignmentUpdateResource> ConsignmentFacadeService { get; private set; }
+        protected IConsignmentFacadeService ConsignmentFacadeService { get; private set; }
 
         protected IFacadeService<Hub, int, HubResource, HubResource> HubFacadeService { get; private set; }
 
@@ -39,7 +39,7 @@
         [SetUp]
         public void EstablishContext()
         {
-            this.ConsignmentFacadeService = Substitute.For<IFacadeService<Consignment, int, ConsignmentResource, ConsignmentUpdateResource>>();
+            this.ConsignmentFacadeService = Substitute.For<IConsignmentFacadeService>();
             this.HubFacadeService = Substitute.For<IFacadeService<Hub, int, HubResource, HubResource>>();
             this.CarrierFacadeService = Substitute.For<IFacadeService<Carrier, string, CarrierResource, CarrierResource>>();
             this.CartonTypeFacadeService = Substitute.For<IFacadeService<CartonType, string, CartonTypeResource, CartonTypeResource>>();

--- a/tests/Integration/Service.Tests/ConsignmentModuleSpecs/WhenGettingAll.cs
+++ b/tests/Integration/Service.Tests/ConsignmentModuleSpecs/WhenGettingAll.cs
@@ -8,7 +8,7 @@
     using Linn.Common.Facade;
     using Linn.Stores.Domain.LinnApps.Consignments;
     using Linn.Stores.Resources.Consignments;
-
+    using Linn.Stores.Resources.RequestResources;
     using Nancy;
     using Nancy.Testing;
 
@@ -28,7 +28,7 @@
             this.consignment1 = new Consignment { ConsignmentId = 1 };
             this.consignment2 = new Consignment { ConsignmentId = 2 };
 
-            this.ConsignmentFacadeService.GetAll()
+            this.ConsignmentFacadeService.GetByRequestResource(Arg.Any<ConsignmentsRequestResource>())
                 .Returns(new SuccessResult<IEnumerable<Consignment>>(new List<Consignment>
                                                                          {
                                                                              this.consignment1, this.consignment2
@@ -51,7 +51,7 @@
         [Test]
         public void ShouldCallService()
         {
-            this.ConsignmentFacadeService.Received().GetAll();
+            this.ConsignmentFacadeService.Received().GetByRequestResource(Arg.Any<ConsignmentsRequestResource>());
         }
 
         [Test]

--- a/tests/Unit/Facade.Tests/ConsignmentFacadeServiceTests/WhenEditingClosedConsignment.cs
+++ b/tests/Unit/Facade.Tests/ConsignmentFacadeServiceTests/WhenEditingClosedConsignment.cs
@@ -61,7 +61,8 @@
             this.updateResource = new ConsignmentUpdateResource
                                       {
                                           HubId = 2222,
-                                          Status = "C"
+                                          Status = "C",
+                                          CarrierRef = "test"
                                       };
                                           
             this.ConsignmentRepository.FindById(this.consignmentId).Returns(consignment);
@@ -80,9 +81,21 @@
         [Test]
         public void ShouldReturnSuccess()
         {
-            this.result.Should().BeOfType<BadRequestResult<Consignment>>();
-            var badRequestResult = (BadRequestResult<Consignment>)this.result;
-            badRequestResult.Message.Should().Be($"Error updating {this.consignmentId} - You cannot edit closed consignment {this.consignmentId}.");
+            this.result.Should().BeOfType<SuccessResult<Consignment>>();
+        }
+
+        [Test]
+        public void ShouldNotUpdateHub()
+        {
+            var successResult = (SuccessResult<Consignment>)this.result;
+            successResult.Data.HubId.Should().Be(1);
+        }
+
+        [Test]
+        public void ShouldUpdateCarrierRef()
+        {
+            var successResult = (SuccessResult<Consignment>)this.result;
+            successResult.Data.CarrierRef.Should().Be("test");
         }
     }
 }


### PR DESCRIPTION
A consignment export info editing page.  Current consignment page doesn't allow for editing after the consignment closed and there is another page in linnapps that this will replace to add carrier references and customs entry details.

For EU consignments all the shipments that go out on the day get the same master carrier ref so added functionality to set this for a bunch of clicked consignments as they were moaning about going in and out of screens.

This is a first draft and may change when I show it to them and they think of other amendments.