### PR TITLE
alter nominal/dept search

### DIFF
--- a/src/Facade/Services/NominalAccountsService.cs
+++ b/src/Facade/Services/NominalAccountsService.cs
@@ -25,7 +25,7 @@
                     => n.Department.Description.ToUpper().Equals(searchTerm)
                        || n.Department.DepartmentCode.Equals(searchTerm)
                        || n.Nominal.Description.ToUpper().Equals(searchTerm)
-                       || n.Nominal.NominalCode.Equals(searchTerm)).Take(5);
+                       || n.Nominal.NominalCode.Equals(searchTerm)).Take(50);
             if (exactMatches.Any())
             {
                 return new SuccessResult<IEnumerable<NominalAccount>>(exactMatches);

--- a/src/Facade/Services/NominalAccountsService.cs
+++ b/src/Facade/Services/NominalAccountsService.cs
@@ -20,10 +20,21 @@
 
         public IResult<IEnumerable<NominalAccount>> GetNominalAccounts(string searchTerm)
         {
+            var exactMatches = this.nominalAccountRepository
+                .FilterBy(n
+                    => n.Department.Description.ToUpper().Equals(searchTerm)
+                       || n.Department.DepartmentCode.Equals(searchTerm)
+                       || n.Nominal.Description.ToUpper().Equals(searchTerm)
+                       || n.Nominal.NominalCode.Equals(searchTerm)).Take(5);
+            if (exactMatches.Any())
+            {
+                return new SuccessResult<IEnumerable<NominalAccount>>(exactMatches);
+            }
+
             var result = this.nominalAccountRepository
-                .FilterBy(n 
+                .FilterBy(n
                     => n.Department.DepartmentCode.ContainsIgnoringCase(searchTerm)
-                    || n.Department.DepartmentCode.ContainsIgnoringCase(searchTerm)
+                    || n.Department.Description.ContainsIgnoringCase(searchTerm)
                     || n.Nominal.NominalCode.ContainsIgnoringCase(searchTerm)
                     || n.Nominal.Description.ContainsIgnoringCase(searchTerm)).Take(50);
             return new SuccessResult<IEnumerable<NominalAccount>>(result);


### PR DESCRIPTION
Played about with this after Chris mentioned IT department example at standup.

Now does exact match search first to bring back things like "IT" for department, + fixed typo/copy paste so that also searches on department.description and not department.departmentCode twice