### PR TITLE
Dpqnew

### DIFF
--- a/src/Domain.LinnApps/Allocation/DespatchPalletQueueScsDetail.cs
+++ b/src/Domain.LinnApps/Allocation/DespatchPalletQueueScsDetail.cs
@@ -1,0 +1,12 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Allocation
+{
+
+    public class DespatchPalletQueueScsDetail
+    {
+        public int PalletNumber { get; set; }
+
+        public string KittedFromTime { get; set; }
+
+        public int PickingSequence { get; set; }
+    }
+}

--- a/src/Facade/Extensions/WarehouseLocationExtensions.cs
+++ b/src/Facade/Extensions/WarehouseLocationExtensions.cs
@@ -15,7 +15,7 @@
                            Level = location.ScsLevelIndex(),
                            Side = location.ScsSideIndex(),
                            Height = location.Pallet.ScsHeight(),
-                           HeatValue = location.Pallet.ScsHeat(),
+                           HeatValue = location.Pallet.Heat ?? 2,
                            RotationAverage = location.Pallet.RotationAverage
                        };
         }

--- a/src/Facade/ResourceBuilders/DespatchPalletQueueScsDetailResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/DespatchPalletQueueScsDetailResourceBuilder.cs
@@ -1,0 +1,27 @@
+﻿namespace Linn.Stores.Facade.ResourceBuilders
+{
+
+    using Linn.Common.Facade;
+    using Linn.Stores.Domain.LinnApps.Allocation;
+    using Linn.Stores.Resources.Allocation;
+
+    public class DespatchPalletQueueScsDetailResourceBuilder : IResourceBuilder<DespatchPalletQueueScsDetail>
+    {
+        public DespatchPalletQueueScsDetailResource Build(DespatchPalletQueueScsDetail despatchPalletQueueDetail)
+        {
+            return new DespatchPalletQueueScsDetailResource
+            {
+                PalletNumber = despatchPalletQueueDetail.PalletNumber,
+                KittedFromTime = despatchPalletQueueDetail.KittedFromTime,
+                PickingSequence = despatchPalletQueueDetail.PickingSequence
+            };
+        }
+
+        public string GetLocation(DespatchPalletQueueScsDetail despatchPalletQueueDetail)
+        {
+            return "/logistics/allocations/despatch-pallet-queue/scs";
+        }
+
+        object IResourceBuilder<DespatchPalletQueueScsDetail>.Build(DespatchPalletQueueScsDetail despatchPalletQueueDetail) => this.Build(despatchPalletQueueDetail);
+    }
+}

--- a/src/Facade/ResourceBuilders/DespatchPalletQueueScsDetailsResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/DespatchPalletQueueScsDetailsResourceBuilder.cs
@@ -1,0 +1,28 @@
+﻿namespace Linn.Stores.Facade.ResourceBuilders
+{
+    using Linn.Common.Facade;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Linn.Stores.Domain.LinnApps.Allocation;
+    using Linn.Stores.Resources.Allocation;
+
+    public class DespatchPalletQueueScsDetailsResourceBuilder : IResourceBuilder<IEnumerable<DespatchPalletQueueScsDetail>>
+    {
+        private readonly DespatchPalletQueueScsDetailResourceBuilder despatchPalletQueueScsDetailResourceBuilder = new DespatchPalletQueueScsDetailResourceBuilder();
+
+        public IEnumerable<DespatchPalletQueueScsDetailResource> Build(IEnumerable<DespatchPalletQueueScsDetail> queueScsDetails)
+        {
+            return queueScsDetails
+                .Select(a => this.despatchPalletQueueScsDetailResourceBuilder.Build(a));
+        }
+
+        object IResourceBuilder<IEnumerable<DespatchPalletQueueScsDetail>>.Build(IEnumerable<DespatchPalletQueueScsDetail> queueScsDetails) => this.Build(queueScsDetails);
+
+        public string GetLocation(IEnumerable<DespatchPalletQueueScsDetail> queueScsDetails)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Facade/Services/AllocationFacadeService.cs
+++ b/src/Facade/Services/AllocationFacadeService.cs
@@ -2,8 +2,10 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using Linn.Common.Facade;
+    using Linn.Common.Persistence;
     using Linn.Common.Reporting.Models;
     using Linn.Stores.Domain.LinnApps.Allocation;
     using Linn.Stores.Domain.LinnApps.Allocation.Models;
@@ -17,10 +19,13 @@
 
         private readonly IAllocationReportsService allocationReportsService;
 
-        public AllocationFacadeService(IAllocationService allocationService, IAllocationReportsService allocationReportsService)
+        private readonly IQueryRepository<DespatchPalletQueueScsDetail> dpqRepository;
+
+        public AllocationFacadeService(IAllocationService allocationService, IAllocationReportsService allocationReportsService, IQueryRepository<DespatchPalletQueueScsDetail> dpqRepository)
         {
             this.allocationService = allocationService;
             this.allocationReportsService = allocationReportsService;
+            this.dpqRepository = dpqRepository;
         }
 
         public IResult<AllocationResult> StartAllocation(AllocationOptionsResource allocationOptionsResource)
@@ -97,6 +102,11 @@
         public IResult<DespatchPalletQueueResult> DespatchPalletQueueReport()
         {
             return new SuccessResult<DespatchPalletQueueResult>(this.allocationReportsService.DespatchPalletQueue());
+        }
+
+        public IResult<IEnumerable<DespatchPalletQueueScsDetail>> DespatchPalletQueueForScs()
+        {
+            return new SuccessResult<IEnumerable<DespatchPalletQueueScsDetail>>(this.dpqRepository.FindAll().ToList());
         }
     }
 }

--- a/src/Facade/Services/IAllocationFacadeService.cs
+++ b/src/Facade/Services/IAllocationFacadeService.cs
@@ -22,5 +22,7 @@
         IResult<ResultsModel> DespatchPickingSummaryReport();
 
         IResult<DespatchPalletQueueResult> DespatchPalletQueueReport();
+
+        IResult<IEnumerable<DespatchPalletQueueScsDetail>> DespatchPalletQueueForScs();
     }
 }

--- a/src/IoC/PersistenceModule.cs
+++ b/src/IoC/PersistenceModule.cs
@@ -156,6 +156,7 @@
             builder.RegisterType<StoresMoveLogRepository>().As<IQueryRepository<StoresMoveLog>>();
             builder.RegisterType<PartLibraryRepository>().As<IRepository<PartLibrary, string>>();
             builder.RegisterType<WarehouseLocationRepository>().As<IQueryRepository<WarehouseLocation>>();
+            builder.RegisterType<DespatchPalletQueueScsDetailsRepository>().As<IQueryRepository<DespatchPalletQueueScsDetail>>();
         }
     }
 }

--- a/src/IoC/ResponsesModule.cs
+++ b/src/IoC/ResponsesModule.cs
@@ -242,6 +242,8 @@
             builder.RegisterType<PartLibraryResourceBuilder>().As<IResourceBuilder<PartLibrary>>();
             builder.RegisterType<PartLibrariesResourceBuilder>().As<IResourceBuilder<IEnumerable<PartLibrary>>>();
             builder.RegisterType<ScsPalletsResourceBuilder>().As<IResourceBuilder<IEnumerable<ScsPallet>>>();
+            builder.RegisterType<DespatchPalletQueueScsDetailResourceBuilder>().As<IResourceBuilder<DespatchPalletQueueScsDetail>>();
+            builder.RegisterType<DespatchPalletQueueScsDetailsResourceBuilder>().As<IResourceBuilder<IEnumerable<DespatchPalletQueueScsDetail>>>();
         }
     }
 }

--- a/src/Persistence.LinnApps/Repositories/DespatchPalletQueueScsDetailsRepository.cs
+++ b/src/Persistence.LinnApps/Repositories/DespatchPalletQueueScsDetailsRepository.cs
@@ -1,0 +1,33 @@
+﻿namespace Linn.Stores.Persistence.LinnApps.Repositories
+{
+    using Linn.Common.Persistence;
+    using Linn.Stores.Domain.LinnApps.Allocation;
+    using System;
+    using System.Linq.Expressions;
+    using System.Linq;
+
+    public class DespatchPalletQueueScsDetailsRepository : IQueryRepository<DespatchPalletQueueScsDetail>
+    {
+        private readonly ServiceDbContext serviceDbContext;
+
+        public DespatchPalletQueueScsDetailsRepository(ServiceDbContext serviceDbContext)
+        {
+            this.serviceDbContext = serviceDbContext;
+        }
+
+        public DespatchPalletQueueScsDetail FindBy(Expression<Func<DespatchPalletQueueScsDetail, bool>> expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IQueryable<DespatchPalletQueueScsDetail> FilterBy(Expression<Func<DespatchPalletQueueScsDetail, bool>> expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        IQueryable<DespatchPalletQueueScsDetail> IQueryRepository<DespatchPalletQueueScsDetail>.FindAll()
+        {
+            return this.serviceDbContext.DespatchPalletQueueScsDetails;
+        }
+    }
+}

--- a/src/Persistence.LinnApps/ServiceDbContext.cs
+++ b/src/Persistence.LinnApps/ServiceDbContext.cs
@@ -266,6 +266,8 @@
 
         public DbSet<WarehouseLocation> WarehouseLocations { get; set; }
 
+        public DbQuery<DespatchPalletQueueScsDetail> DespatchPalletQueueScsDetails { get; set; }
+
         protected override void OnModelCreating(ModelBuilder builder)
         {
             this.BuildParts(builder);
@@ -393,6 +395,7 @@
             this.BuildPartLibraries(builder);
             this.BuildWarehouseLocations(builder);
             this.BuildWarehousePallets(builder);
+            this.QueryDespatchPalletQueueScsDetails(builder);
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -2289,6 +2292,14 @@
             q.Property(a => a.SpeedFactor).HasColumnName("SPEED_FACTOR");
             q.Property(a => a.RotationAverage).HasColumnName("ROTATION_AVERAGE");
             q.Property(a => a.Heat).HasColumnName("HEAT");
+        }
+
+        private void QueryDespatchPalletQueueScsDetails(ModelBuilder builder)
+        {
+            var q = builder.Query<DespatchPalletQueueScsDetail>().ToView("V_DPQ_SUMMARY_FOR_SCS");
+            q.Property(v => v.KittedFromTime).HasColumnName("KITTED_FROM");
+            q.Property(v => v.PalletNumber).HasColumnName("PALLET_NUMBER");
+            q.Property(v => v.PickingSequence).HasColumnName("PICKING_SEQUENCE");
         }
     }
 }

--- a/src/Resources/Allocation/DespatchPalletQueueScsDetailResource.cs
+++ b/src/Resources/Allocation/DespatchPalletQueueScsDetailResource.cs
@@ -1,0 +1,11 @@
+﻿namespace Linn.Stores.Resources.Allocation
+{
+    public class DespatchPalletQueueScsDetailResource
+    {
+        public int PalletNumber { get; set; }
+
+        public string KittedFromTime { get; set; }
+
+        public int PickingSequence { get; set; }
+    }
+}

--- a/src/Service/Modules/AllocationModule.cs
+++ b/src/Service/Modules/AllocationModule.cs
@@ -43,6 +43,7 @@
             this.Put("/logistics/sos-alloc-details/{id:int}", p => this.UpdateAllocDetail(p.id));
             this.Get("/logistics/allocations/despatch-picking-summary", _ => this.GetPickingSummaryReport());
             this.Get("/logistics/allocations/despatch-pallet-queue", _ => this.GetPalletQueueReport());
+            this.Get("/logistics/allocations/despatch-pallet-queue/scs", _ => this.GetPalletQueueForScs());
         }
 
         private object GetPalletQueueReport()
@@ -129,6 +130,11 @@
                 .WithModel(results)
                 .WithMediaRangeModel("text/html", ApplicationSettings.Get)
                 .WithView("Index");
+        }
+
+        private object GetPalletQueueForScs()
+        {
+            return this.Negotiate.WithModel(this.allocationFacadeService.DespatchPalletQueueForScs());
         }
 
         private object GetApp()

--- a/tests/Unit/Facade.Tests/AllocationFacadeServiceTests/ContextBase.cs
+++ b/tests/Unit/Facade.Tests/AllocationFacadeServiceTests/ContextBase.cs
@@ -1,5 +1,6 @@
 ﻿namespace Linn.Stores.Facade.Tests.AllocationFacadeServiceTests
 {
+    using Linn.Common.Persistence;
     using Linn.Stores.Domain.LinnApps.Allocation;
     using Linn.Stores.Facade.Services;
 
@@ -15,12 +16,15 @@
 
         protected IAllocationReportsService AllocationReportsService { get;  private set; }
 
+        protected IQueryRepository<DespatchPalletQueueScsDetail> DpqRepository { get; private set; }
+
         [SetUp]
         public void SetUpContext()
         {
             this.AllocationService = Substitute.For<IAllocationService>();
             this.AllocationReportsService = Substitute.For<IAllocationReportsService>();
-            this.Sut = new AllocationFacadeService(this.AllocationService, this.AllocationReportsService);
+            this.DpqRepository = Substitute.For<IQueryRepository<DespatchPalletQueueScsDetail>>();
+            this.Sut = new AllocationFacadeService(this.AllocationService, this.AllocationReportsService, this.DpqRepository);
         }
     }
 }

--- a/tests/Unit/Facade.Tests/AllocationFacadeServiceTests/WhenGettingDespatchPalletQueueForScs.cs
+++ b/tests/Unit/Facade.Tests/AllocationFacadeServiceTests/WhenGettingDespatchPalletQueueForScs.cs
@@ -1,0 +1,56 @@
+﻿namespace Linn.Stores.Facade.Tests.AllocationFacadeServiceTests
+{
+    using Linn.Common.Facade;
+    using NSubstitute;
+    using NUnit.Framework;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Allocation;
+
+    public class WhenGettingDespatchPalletQueueForScs : ContextBase
+    {
+        private IResult<IEnumerable<DespatchPalletQueueScsDetail>> result;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var dpq = new List<DespatchPalletQueueScsDetail>()
+                          {
+                              new DespatchPalletQueueScsDetail
+                                  {
+                                      PalletNumber = 1, KittedFromTime = "12:00", PickingSequence = 1
+                                  },
+                              new DespatchPalletQueueScsDetail
+                                  {
+                                      PalletNumber = 2, KittedFromTime = "12:01", PickingSequence = 2
+                                  },
+                              new DespatchPalletQueueScsDetail
+                                  {
+                                      PalletNumber = 3, KittedFromTime = "12:02", PickingSequence = 3
+                                  },
+                          };
+
+
+            this.DpqRepository.FindAll().Returns(dpq.AsQueryable());
+
+            this.result = this.Sut.DespatchPalletQueueForScs();
+        }
+
+        [Test]
+        public void ShouldCallRepository()
+        {
+            this.DpqRepository.Received().FindAll();
+        }
+
+        [Test]
+        public void ShouldReturnSuccess()
+        {
+            this.result.Should().BeOfType<SuccessResult<IEnumerable<DespatchPalletQueueScsDetail>>>();
+            var dataResult = ((SuccessResult<IEnumerable<DespatchPalletQueueScsDetail>>)this.result).Data;
+            dataResult.Count().Should().Be(3);
+        }
+    }
+}


### PR DESCRIPTION
providing an endpoint that the new SCS could use to make a DPQ front end that calls DPQ

endpoint is http://localhost:51698/logistics/allocations/despatch-pallet-queue/scs

returns something like 

{
	"data": [
		{
			"palletNumber": 660,
			"kittedFromTime": "now",
			"pickingSequence": 99
		}
	]
}