### PR TITLE
Storepallets

### DIFF
--- a/src/Domain.LinnApps/Domain.LinnApps.csproj
+++ b/src/Domain.LinnApps/Domain.LinnApps.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="Linn.Common.Reporting" Version="1.6.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Domain\Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Domain.LinnApps/ExternalServices/IScsPalletsRepository.cs
+++ b/src/Domain.LinnApps/ExternalServices/IScsPalletsRepository.cs
@@ -1,0 +1,12 @@
+﻿namespace Linn.Stores.Domain.LinnApps.ExternalServices
+{
+    using System.Collections.Generic;
+
+    using Linn.Stores.Domain.LinnApps.Scs;
+
+    public interface IScsPalletsRepository 
+    {
+         void ReplaceAll(
+             IEnumerable<ScsStorePallet> pallets);
+    }
+}

--- a/src/Domain.LinnApps/IWarehouseService.cs
+++ b/src/Domain.LinnApps/IWarehouseService.cs
@@ -1,6 +1,5 @@
 ﻿namespace Linn.Stores.Domain.LinnApps
 {
-    using System.Collections;
     using System.Collections.Generic;
 
     using Linn.Stores.Domain.LinnApps.Models;

--- a/src/Domain.LinnApps/Scs/ScsStorePallet.cs
+++ b/src/Domain.LinnApps/Scs/ScsStorePallet.cs
@@ -1,0 +1,55 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Scs
+{
+    using System;
+
+    public class ScsStorePallet
+    {
+        public ScsStorePallet()
+        {
+            // for EF
+        }
+
+        public ScsStorePallet(ScsPallet pallet)
+        {
+            this.PalletNumber = pallet.PalletNumber;
+            this.Allocated = pallet.Allocated ? "Y" : "N";
+            this.Disabled = pallet.Disabled ? "Y" : "N";
+            this.HeatValue = pallet.HeatValue;
+            this.Height = pallet.Height;
+            this.SizeCode = pallet.SizeCode();
+            this.Area = pallet.Area;
+            this.Column = pallet.Column;
+            this.Level = pallet.Level;
+            this.Side = pallet.Side;
+            this.LastUpdated = DateTime.Now;
+            this.RotationAverage = pallet.RotationAverage;
+            this.UserFriendlyName = pallet.UserFriendlyName();
+        }
+
+        public int PalletNumber { get; set; }
+
+        public string Allocated { get; set; }
+
+        public string Disabled { get; set; }
+
+        public int HeatValue { get; set; }
+
+        public int Height { get; set; }
+
+        public string SizeCode { get; set; }
+
+        public decimal? RotationAverage { get; set; }
+
+        public int Area { get; set; }
+
+        public int Column { get; set; }
+
+        public int Level { get; set; }
+
+        public int Side { get; set; }
+
+        public string UserFriendlyName { get; set; }
+
+        public DateTime LastUpdated { get; set; }
+    }
+}

--- a/src/Domain/ScsPallet.cs
+++ b/src/Domain/ScsPallet.cs
@@ -1,7 +1,5 @@
 ﻿namespace Linn.Stores.Domain
 {
-    using Linn.Stores.Domain.LinnApps.Scs;
-
     public class ScsPallet : StoresAddress
     {
         public int PalletNumber { get; set; }

--- a/src/Domain/ScsPallet.cs
+++ b/src/Domain/ScsPallet.cs
@@ -1,4 +1,4 @@
-﻿namespace Linn.Stores.Domain
+﻿namespace Linn.Stores.Domain.LinnApps.Scs
 {
     public class ScsPallet : StoresAddress
     {
@@ -14,5 +14,118 @@
 
         // need to run PL/SQL function CALC_PALLET_ROTATIONS to refresh this
         public decimal? RotationAverage { get; set; }
+
+        public string SizeCode()
+        {
+            switch (this.Height)
+            {
+                case 2:
+                    return "H";
+                case 1:
+                    return "M";
+                default:
+                    return "L";
+            }
+        }
+
+        public string UserFriendlyName()
+        {
+            if (this.Area == 6)
+            {
+                // benches
+                return $"B{this.Column}";
+            }
+
+            if (this.Area == 5)
+            {
+                // agvs
+                return $"AGV{this.Column}";
+            }
+
+            var sideStr = this.Side == 0 ? "L" : "R";
+
+            if (this.Area == 2)
+            {
+                if (this.Column == 0)
+                {
+                    if (this.Level == 5)
+                    {
+                        return this.Side == 0 ? "U1" : "U2";
+                    }
+                    else if (Level == 1)
+                    {
+                        return this.Side == 0 ? "B5" : "B6";
+                    }
+                }
+                if (this.Column == 1)
+                {
+                    if (this.Level == 5)
+                    {
+                        return this.Side == 0 ? "SDA" : "SDB";
+                    }
+                    else if (Level == 1)
+                    {
+                        return this.Side == 0 ? "SAA" : "SAB";
+                    }
+                }
+                return $"SA{this.Column.ToString().PadLeft(3, '0')}{this.Level.ToString().PadLeft(2, '0')}{sideStr}";
+            }
+
+            if (this.Area == 3)
+            {
+                if (this.Column == 0)
+                {
+                    if (this.Level == 5)
+                    {
+                        return this.Side == 0 ? "U3" : "U4";
+                    }
+                    else if (Level == 1)
+                    {
+                        return this.Side == 0 ? "B7" : "B8";
+                    }
+                }
+                if (this.Column == 1)
+                {
+                    if (this.Level == 5)
+                    {
+                        return this.Side == 0 ? "SEA" : "SEB";
+                    }
+                    else if (Level == 1)
+                    {
+                        return this.Side == 0 ? "SBA" : "SBB";
+                    }
+                }
+                return $"SB{this.Column.ToString().PadLeft(3, '0')}{this.Level.ToString().PadLeft(2, '0')}{sideStr}";
+            }
+
+            if (this.Area == 4)
+            {
+                if (this.Column == 0)
+                {
+                    if (this.Level == 5)
+                    {
+                        return this.Side == 0 ? "U5" : "U6";
+                    }
+                    else if (Level == 1)
+                    {
+                        return this.Side == 0 ? "B9" : "B10";
+                    }
+                }
+                if (this.Column == 1)
+                {
+                    if (this.Level == 5)
+                    {
+                        return this.Side == 0 ? "SEA" : "SEB";
+                    }
+                    else if (Level == 1)
+                    {
+                        return this.Side == 0 ? "SCA" : "SCB";
+                    }
+                }
+                return $"SC{this.Column.ToString().PadLeft(3, '0')}{this.Level.ToString().PadLeft(2, '0')}{sideStr}";
+            }
+
+            return string.Empty;
+        }
     }
 }

--- a/src/Domain/ScsPallet.cs
+++ b/src/Domain/ScsPallet.cs
@@ -1,5 +1,7 @@
-﻿namespace Linn.Stores.Domain.LinnApps.Scs
+﻿namespace Linn.Stores.Domain
 {
+    using Linn.Stores.Domain.LinnApps.Scs;
+
     public class ScsPallet : StoresAddress
     {
         public int PalletNumber { get; set; }
@@ -52,7 +54,7 @@
                     {
                         return this.Side == 0 ? "U1" : "U2";
                     }
-                    else if (Level == 1)
+                    else if (this.Level == 1)
                     {
                         return this.Side == 0 ? "B5" : "B6";
                     }
@@ -63,7 +65,7 @@
                     {
                         return this.Side == 0 ? "SDA" : "SDB";
                     }
-                    else if (Level == 1)
+                    else if (this.Level == 1)
                     {
                         return this.Side == 0 ? "SAA" : "SAB";
                     }
@@ -79,7 +81,7 @@
                     {
                         return this.Side == 0 ? "U3" : "U4";
                     }
-                    else if (Level == 1)
+                    else if (this.Level == 1)
                     {
                         return this.Side == 0 ? "B7" : "B8";
                     }
@@ -90,7 +92,7 @@
                     {
                         return this.Side == 0 ? "SEA" : "SEB";
                     }
-                    else if (Level == 1)
+                    else if (this.Level == 1)
                     {
                         return this.Side == 0 ? "SBA" : "SBB";
                     }
@@ -106,7 +108,7 @@
                     {
                         return this.Side == 0 ? "U5" : "U6";
                     }
-                    else if (Level == 1)
+                    else if (this.Level == 1)
                     {
                         return this.Side == 0 ? "B9" : "B10";
                     }
@@ -117,7 +119,7 @@
                     {
                         return this.Side == 0 ? "SEA" : "SEB";
                     }
-                    else if (Level == 1)
+                    else if (this.Level == 1)
                     {
                         return this.Side == 0 ? "SCA" : "SCB";
                     }

--- a/src/Domain/StoresAddress.cs
+++ b/src/Domain/StoresAddress.cs
@@ -1,4 +1,4 @@
-﻿namespace Linn.Stores.Domain
+﻿namespace Linn.Stores.Domain.LinnApps.Scs
 {
     using System;
     using System.Collections.Generic;

--- a/src/Domain/StoresAddress.cs
+++ b/src/Domain/StoresAddress.cs
@@ -1,9 +1,5 @@
-﻿namespace Linn.Stores.Domain.LinnApps.Scs
+﻿namespace Linn.Stores.Domain
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-
     public class StoresAddress
     {
         public int Area { get; set; }

--- a/src/Facade/Extensions/WarehouseLocationExtensions.cs
+++ b/src/Facade/Extensions/WarehouseLocationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Linn.Stores.Facade.Extensions
 {
     using Linn.Stores.Domain;
+    using Linn.Stores.Domain.LinnApps.Scs;
     using Linn.Stores.Domain.LinnApps.Wcs;
 
     public static class WarehouseLocationExtensions

--- a/src/Facade/Extensions/WarehouseLocationExtensions.cs
+++ b/src/Facade/Extensions/WarehouseLocationExtensions.cs
@@ -15,7 +15,7 @@
                            Level = location.ScsLevelIndex(),
                            Side = location.ScsSideIndex(),
                            Height = location.Pallet.ScsHeight(),
-                           HeatValue = location.Pallet.ScsHeat(),
+                           HeatValue = location.Pallet.Heat ?? 2,
                            RotationAverage = location.Pallet.RotationAverage
                        };
         }

--- a/src/Facade/ResourceBuilders/ScsPalletResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/ScsPalletResourceBuilder.cs
@@ -4,6 +4,7 @@
 
     using Linn.Common.Facade;
     using Linn.Stores.Domain;
+    using Linn.Stores.Domain.LinnApps.Scs;
     using Linn.Stores.Resources.Scs;
 
     public class ScsPalletResourceBuilder : IResourceBuilder<ScsPallet>

--- a/src/Facade/ResourceBuilders/ScsPalletsResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/ScsPalletsResourceBuilder.cs
@@ -7,6 +7,7 @@
     using System.Linq;
 
     using Linn.Stores.Resources.Scs;
+    using Linn.Stores.Domain.LinnApps.Scs;
 
     public class ScsPalletsResourceBuilder : IResourceBuilder<IEnumerable<ScsPallet>>
     {

--- a/src/Facade/Services/IWarehouseFacadeService.cs
+++ b/src/Facade/Services/IWarehouseFacadeService.cs
@@ -4,9 +4,9 @@
     using Linn.Stores.Domain.LinnApps.Models;
     using System.Collections.Generic;
 
+    using Linn.Stores.Domain;
     using Linn.Stores.Domain.LinnApps.Wcs;
     using Linn.Stores.Resources;
-    using Linn.Stores.Domain.LinnApps.Scs;
     using Linn.Stores.Resources.Scs;
 
     public interface IWarehouseFacadeService

--- a/src/Facade/Services/IWarehouseFacadeService.cs
+++ b/src/Facade/Services/IWarehouseFacadeService.cs
@@ -6,7 +6,8 @@
 
     using Linn.Stores.Domain.LinnApps.Wcs;
     using Linn.Stores.Resources;
-    using Linn.Stores.Domain;
+    using Linn.Stores.Domain.LinnApps.Scs;
+    using Linn.Stores.Resources.Scs;
 
     public interface IWarehouseFacadeService
     {
@@ -21,5 +22,7 @@
         IResult<WarehouseLocation> GetPalletAtLocation(string location);
 
         IResult<IEnumerable<ScsPallet>> GetScsPallets();
+
+        IResult<MessageResult> StorePallets(ScsPalletsResource resource);
     }
 }

--- a/src/Facade/Services/WarehouseFacadeService.cs
+++ b/src/Facade/Services/WarehouseFacadeService.cs
@@ -10,6 +10,7 @@
     using System.Collections.Generic;
     using System.Linq;
 
+    using Linn.Stores.Domain;
     using Linn.Stores.Domain.LinnApps.ExternalServices;
     using Linn.Stores.Facade.Extensions;
     using Linn.Stores.Domain.LinnApps.Scs;

--- a/src/IoC/PersistenceModule.cs
+++ b/src/IoC/PersistenceModule.cs
@@ -157,6 +157,7 @@
             builder.RegisterType<PartLibraryRepository>().As<IRepository<PartLibrary, string>>();
             builder.RegisterType<WarehouseLocationRepository>().As<IQueryRepository<WarehouseLocation>>();
             builder.RegisterType<DespatchPalletQueueScsDetailsRepository>().As<IQueryRepository<DespatchPalletQueueScsDetail>>();
+            builder.RegisterType<ScsPalletFastRepository>().As<IScsPalletsRepository>();
         }
     }
 }

--- a/src/IoC/ResponsesModule.cs
+++ b/src/IoC/ResponsesModule.cs
@@ -21,6 +21,7 @@
     using Linn.Stores.Domain.LinnApps.Parts;
     using Linn.Stores.Domain.LinnApps.Requisitions;
     using Linn.Stores.Domain.LinnApps.Requisitions.Models;
+    using Linn.Stores.Domain.LinnApps.Scs;
     using Linn.Stores.Domain.LinnApps.StockLocators;
     using Linn.Stores.Domain.LinnApps.StockMove.Models;
     using Linn.Stores.Domain.LinnApps.Tpk;

--- a/src/Persistence.LinnApps/Persistence.LinnApps.csproj
+++ b/src/Persistence.LinnApps/Persistence.LinnApps.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Linn.Common.Logging" Version="2.0.0" />
     <PackageReference Include="Linn.Common.Persistence" Version="3.0.0" />
     <PackageReference Include="Linn.Common.Persistence.EntityFramework" Version="2.0.2" />
+    <PackageReference Include="Linn.Common.Proxy.LinnApps" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.2.0" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.60" />

--- a/src/Persistence.LinnApps/Repositories/ScsPalletFastRepository.cs
+++ b/src/Persistence.LinnApps/Repositories/ScsPalletFastRepository.cs
@@ -1,0 +1,79 @@
+﻿namespace Linn.Stores.Persistence.LinnApps.Repositories
+{
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Linq;
+
+    using Linn.Common.Proxy.LinnApps;
+    using Linn.Stores.Domain.LinnApps.ExternalServices;
+    using Linn.Stores.Domain.LinnApps.Scs;
+
+    using Microsoft.EntityFrameworkCore.Internal;
+
+    using Oracle.ManagedDataAccess.Client;
+    using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
+
+    public class ScsPalletFastRepository : IScsPalletsRepository
+    {
+        private readonly IDatabaseService databaseService;
+
+        public ScsPalletFastRepository(IDatabaseService databaseService)
+        {
+            this.databaseService = databaseService;
+        }
+
+        public void ReplaceAll(IEnumerable<ScsStorePallet> pallets)
+        {
+            using (var connection = this.databaseService.GetConnection())
+            {
+                connection.Open();
+                this.RunCommand(connection, "truncate table scs_pallets");
+                if (EnumerableExtensions.Any(pallets))
+                {
+                    // new type of crap 
+                    var insertSql = "INSERT INTO SCS_PALLETS(PALLET_NUMBER, LAST_UPDATED, AREA, COL, LVL, SIDE, HEIGHT, USER_FRIENDLY_NAME) VALUES (:1,SYSDATE,:2,:3,:4,:5,:6,:7)";
+                    var cmd = new OracleCommand(insertSql, connection)
+                                  {
+                        CommandType = CommandType.Text
+                                  };
+                    cmd.Parameters.Add(":1", OracleDbType.Int32, ParameterDirection.Input);
+                    cmd.Parameters.Add(":2", OracleDbType.Int32, ParameterDirection.Input);
+                    cmd.Parameters.Add(":3", OracleDbType.Int32, ParameterDirection.Input);
+                    cmd.Parameters.Add(":4", OracleDbType.Int32, ParameterDirection.Input);
+                    cmd.Parameters.Add(":5", OracleDbType.Int32, ParameterDirection.Input);
+                    cmd.Parameters.Add(":6", OracleDbType.Int32, ParameterDirection.Input);
+                    cmd.Parameters.Add(":7", OracleDbType.Varchar2, ParameterDirection.Input);
+
+                    cmd.ArrayBindCount = pallets.Count();
+
+                    cmd.Parameters[":1"].Value = pallets.Select(p => p.PalletNumber).ToArray();
+                    cmd.Parameters[":2"].Value = pallets.Select(p => p.Area).ToArray();
+                    cmd.Parameters[":3"].Value = pallets.Select(p => p.Column).ToArray();
+                    cmd.Parameters[":4"].Value = pallets.Select(p => p.Level).ToArray();
+                    cmd.Parameters[":5"].Value = pallets.Select(p => p.Side).ToArray();
+                    cmd.Parameters[":6"].Value = pallets.Select(p => p.Height).ToArray();
+                    cmd.Parameters[":7"].Value = pallets.Select(p => p.UserFriendlyName).ToArray();
+
+                    cmd.ExecuteNonQuery();
+
+                    this.RunCommand(connection,"COMMIT");
+                }
+                connection.Close();
+            }
+        }
+
+        private void RunCommand(OracleConnection connection, string cmdString)
+        {
+            var cmd = new OracleCommand(cmdString, connection)
+                          {
+                              CommandType = CommandType.Text
+                          };
+            cmd.ExecuteNonQuery();
+        }
+
+        private string InsertSQL(ScsStorePallet pallet)
+        {
+            return $"INSERT INTO SCS_PALLETS(PALLET_NUMBER, LAST_UPDATED) VALUES ({pallet.PalletNumber}, SYSDATE)";
+        }
+    }
+}

--- a/src/Persistence.LinnApps/Repositories/ScsPalletsRepository.cs
+++ b/src/Persistence.LinnApps/Repositories/ScsPalletsRepository.cs
@@ -1,0 +1,72 @@
+﻿namespace Linn.Stores.Persistence.LinnApps.Repositories
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    using Linn.Stores.Domain.LinnApps.ExternalServices;
+    using Linn.Stores.Domain.LinnApps.Scs;
+
+    using Microsoft.EntityFrameworkCore;
+
+    public class ScsPalletsRepository : IScsPalletsRepository
+    {
+        private readonly ServiceDbContext serviceDbContext;
+
+        public ScsPalletsRepository(ServiceDbContext serviceDbContext)
+        {
+            this.serviceDbContext = serviceDbContext;
+        }
+
+        public ScsStorePallet FindById(int key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IQueryable<ScsStorePallet> FindAll()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Add(ScsStorePallet entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Remove(ScsStorePallet entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ScsStorePallet FindBy(Expression<Func<ScsStorePallet, bool>> expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IQueryable<ScsStorePallet> FilterBy(Expression<Func<ScsStorePallet, bool>> expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ReplaceAll(IEnumerable<ScsStorePallet> pallets)
+        {
+            // TODO make the replace only remove pallets that are missing from pallets, add new pallets and update existing ones
+            // in this version of EF this is still crippling slow about 20 minutes for 2000 pallets which is why there is a fast
+            // cheaty way
+
+            // should replace the existing SCS_PALLETS with this one
+            var existingPallets = this.serviceDbContext.ScsPallets.AsNoTracking().ToList();
+            if (existingPallets.Any())
+            {
+                this.serviceDbContext.ScsPallets.RemoveRange(existingPallets);
+                // if we don't persist to DB not sure if doing an immediate AddRange would cause issues with primary keys
+                this.serviceDbContext.SaveChanges();
+            }
+
+            this.serviceDbContext.ScsPallets.AddRange(pallets);
+
+            this.serviceDbContext.SaveChanges(); // this takes 20 minutes with tracking
+        }
+    }
+}

--- a/src/Persistence.LinnApps/ServiceDbContext.cs
+++ b/src/Persistence.LinnApps/ServiceDbContext.cs
@@ -12,6 +12,7 @@
     using Linn.Stores.Domain.LinnApps.Parts;
     using Linn.Stores.Domain.LinnApps.ProductionTriggers;
     using Linn.Stores.Domain.LinnApps.Requisitions;
+    using Linn.Stores.Domain.LinnApps.Scs;
     using Linn.Stores.Domain.LinnApps.Sos;
     using Linn.Stores.Domain.LinnApps.StockLocators;
     using Linn.Stores.Domain.LinnApps.StockMove.Models;
@@ -268,6 +269,8 @@
 
         public DbQuery<DespatchPalletQueueScsDetail> DespatchPalletQueueScsDetails { get; set; }
 
+        public DbSet<ScsStorePallet> ScsPallets { get; set; }
+
         protected override void OnModelCreating(ModelBuilder builder)
         {
             this.BuildParts(builder);
@@ -396,6 +399,7 @@
             this.BuildWarehouseLocations(builder);
             this.BuildWarehousePallets(builder);
             this.QueryDespatchPalletQueueScsDetails(builder);
+            this.BuildScsStorePallets(builder);
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -2300,6 +2304,26 @@
             q.Property(v => v.KittedFromTime).HasColumnName("KITTED_FROM");
             q.Property(v => v.PalletNumber).HasColumnName("PALLET_NUMBER");
             q.Property(v => v.PickingSequence).HasColumnName("PICKING_SEQUENCE");
+        }
+
+        private void BuildScsStorePallets(ModelBuilder builder)
+        {
+            var q = builder.Entity<ScsStorePallet>().ToTable("SCS_PALLETS");
+
+            q.HasKey(a => a.PalletNumber);
+            q.Property(a => a.PalletNumber).HasColumnName("PALLET_NUMBER");
+            q.Property(a => a.SizeCode).HasColumnName("SIZE_CODE").HasMaxLength(1);
+            q.Property(a => a.UserFriendlyName).HasColumnName("USER_FRIENDLY_NAME").HasMaxLength(255);
+            q.Property(a => a.RotationAverage).HasColumnName("ROTATION_AVERAGE");
+            q.Property(a => a.HeatValue).HasColumnName("HEAT_VALUE");
+            q.Property(a => a.Height).HasColumnName("HEIGHT");
+            q.Property(a => a.Allocated).HasColumnName("ALLOCATED").HasMaxLength(1);
+            q.Property(a => a.Disabled).HasColumnName("DISABLED").HasMaxLength(1);
+            q.Property(a => a.Area).HasColumnName("AREA");
+            q.Property(a => a.Column).HasColumnName("COL");
+            q.Property(a => a.Level).HasColumnName("LVL");
+            q.Property(a => a.Side).HasColumnName("SIDE");
+            q.Property(a => a.LastUpdated).HasColumnName("LAST_UPDATED");
         }
     }
 }

--- a/src/Service/Modules/WarehouseModule.cs
+++ b/src/Service/Modules/WarehouseModule.cs
@@ -6,6 +6,7 @@
     using Linn.Stores.Facade.Services;
     using Linn.Stores.Resources;
     using Linn.Stores.Resources.RequestResources;
+    using Linn.Stores.Resources.Scs;
     using Linn.Stores.Service.Extensions;
 
     using Nancy;
@@ -23,6 +24,7 @@
             this.Post("/logistics/wcs/warehouse-tasks", _ => this.AddWarehouseTask());
             this.Get("/logistics/wcs/warehouse-pallets/{palletId:int}", parameters => this.GetWarehousePallet(parameters.palletId));
             this.Get("/logistics/wcs/warehouse-pallets/scs", _ => this.QueryScsPallets());
+            this.Post("/logistics/wcs/warehouse-pallets/scs", _ => this.PostScsPallets());
             this.Get("/logistics/wcs/warehouse-pallets", _ => this.QueryWarehousePallet());
         }
 
@@ -71,6 +73,14 @@
 
             return this.Negotiate
                 .WithModel(result);
+        }
+
+        private object PostScsPallets()
+        {
+            var resource = this.Bind<ScsPalletsResource>();
+
+            return this.Negotiate.WithModel(
+                this.warehouseFacadeService.StorePallets(resource));
         }
     }
 }

--- a/src/Service/ResponseProcessors/ScsPalletsResponseProcessor.cs
+++ b/src/Service/ResponseProcessors/ScsPalletsResponseProcessor.cs
@@ -8,6 +8,7 @@
 
     using Linn.Common.Facade;
     using Linn.Stores.Domain;
+    using Linn.Stores.Domain.LinnApps.Scs;
 
     public class ScsPalletsResponseProcessor : JsonResponseProcessor<IEnumerable<ScsPallet>>
     {

--- a/tests/Unit/Domain.Tests/ScsPalletTests/ContextBase.cs
+++ b/tests/Unit/Domain.Tests/ScsPalletTests/ContextBase.cs
@@ -1,6 +1,5 @@
 ﻿namespace Linn.Stores.Domain.Tests.ScsPalletTests
 {
-    using Linn.Stores.Domain.LinnApps.Scs;
     using NUnit.Framework;
 
     public class ContextBase

--- a/tests/Unit/Domain.Tests/ScsPalletTests/ContextBase.cs
+++ b/tests/Unit/Domain.Tests/ScsPalletTests/ContextBase.cs
@@ -1,0 +1,16 @@
+﻿namespace Linn.Stores.Domain.Tests.ScsPalletTests
+{
+    using Linn.Stores.Domain.LinnApps.Scs;
+    using NUnit.Framework;
+
+    public class ContextBase
+    {
+        protected ScsPallet Sut { get; private set; }
+
+        [SetUp]
+        public void SetUpContext()
+        {
+            this.Sut = new ScsPallet();
+        }
+    }
+}

--- a/tests/Unit/Domain.Tests/ScsPalletTests/WhenGettingUserFriendlyNameOfAislePallet.cs
+++ b/tests/Unit/Domain.Tests/ScsPalletTests/WhenGettingUserFriendlyNameOfAislePallet.cs
@@ -1,0 +1,25 @@
+﻿namespace Linn.Stores.Domain.Tests.ScsPalletTests
+{
+    using FluentAssertions;
+
+    using NUnit.Framework;
+
+    public class WhenGettingUserFriendlyNameOfAislePallet : ContextBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            this.Sut.PalletNumber = 1000;
+            this.Sut.Area = 3;
+            this.Sut.Column = 29;
+            this.Sut.Level = 6;
+            this.Sut.Side = 0;
+        }
+
+        [Test]
+        public void ShouldHaveRightAreaCode()
+        {
+            this.Sut.UserFriendlyName().Should().Be("SB02906L");
+        }
+    }
+}

--- a/tests/Unit/Domain.Tests/ScsPalletTests/WhenGettingUserFriendlyNameOfBench.cs
+++ b/tests/Unit/Domain.Tests/ScsPalletTests/WhenGettingUserFriendlyNameOfBench.cs
@@ -1,0 +1,24 @@
+﻿namespace Linn.Stores.Domain.Tests.ScsPalletTests
+{
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class WhenGettingUserFriendlyNameOfBench : ContextBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            this.Sut.PalletNumber = 1000;
+            this.Sut.Area = 6;
+            this.Sut.Column = 29;
+            this.Sut.Level = 0;
+            this.Sut.Side = 0;
+        }
+
+        [Test]
+        public void ShouldHaveRightAreaCode()
+        {
+            this.Sut.UserFriendlyName().Should().Be("B29");
+        }
+    }
+}

--- a/tests/Unit/Domain.Tests/ScsPalletTests/WhenGettingUserFriendlyNameOfUpperConveyor.cs
+++ b/tests/Unit/Domain.Tests/ScsPalletTests/WhenGettingUserFriendlyNameOfUpperConveyor.cs
@@ -1,0 +1,25 @@
+﻿namespace Linn.Stores.Domain.Tests.ScsPalletTests
+{
+    using FluentAssertions;
+
+    using NUnit.Framework;
+
+    public class WhenGettingUserFriendlyNameOfUpperConveyor : ContextBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            this.Sut.PalletNumber = 1000;
+            this.Sut.Area = 2;
+            this.Sut.Column = 0;
+            this.Sut.Level = 5;
+            this.Sut.Side = 1;
+        }
+
+        [Test]
+        public void ShouldHaveRightAreaCode()
+        {
+            this.Sut.UserFriendlyName().Should().Be("U2");
+        }
+    }
+}

--- a/tests/Unit/Facade.Tests/WarehouseFacadeServiceTests/ContextBase.cs
+++ b/tests/Unit/Facade.Tests/WarehouseFacadeServiceTests/ContextBase.cs
@@ -2,6 +2,7 @@
 {
     using Linn.Common.Persistence;
     using Linn.Stores.Domain.LinnApps;
+    using Linn.Stores.Domain.LinnApps.ExternalServices;
     using Linn.Stores.Domain.LinnApps.Wcs;
     using Linn.Stores.Facade.Services;
 
@@ -17,12 +18,15 @@
 
         protected IRepository<Employee, int> EmployeeRepository { get; private set; }
 
+        protected IScsPalletsRepository ScsPalletsRepository { get; private set; }
+
         [SetUp]
         public void SetUpContext()
         {
             this.WarehouseService = Substitute.For<IWarehouseService>();
             this.EmployeeRepository = Substitute.For<IRepository<Employee, int>>();
-            this.Sut = new WarehouseFacadeService(this.WarehouseService, this.EmployeeRepository);
+            this.ScsPalletsRepository = Substitute.For<IScsPalletsRepository>();
+            this.Sut = new WarehouseFacadeService(this.WarehouseService, this.EmployeeRepository, this.ScsPalletsRepository);
         }
     }
 }

--- a/tests/Unit/Facade.Tests/WarehouseFacadeServiceTests/WhenGettingScsPallets.cs
+++ b/tests/Unit/Facade.Tests/WarehouseFacadeServiceTests/WhenGettingScsPallets.cs
@@ -13,6 +13,7 @@
     using NSubstitute;
     using FluentAssertions;
     using Linn.Stores.Domain.LinnApps.Models;
+    using Linn.Stores.Domain.LinnApps.Scs;
 
     public class WhenGettingScsPallets : ContextBase
     {


### PR DESCRIPTION
This is the endpoint that lets you take the SCS JSON Store Pallets format and post it to 
http://localhost:51698/logistics/wcs/warehouse-pallets/scs

which makes 2000-ish basic pallet records in SCS_PALLETS

The EF version did all the fields but took 20 minutes to run - the fast awful code "Fast" repository can do it around 5s but only writes the essential fields we would need back in Oracle pallet number, location and height.  

This will enable us to fix Despatch Pallet Queue with just a SQL tweak to V_DPS_LINN on go live.  It also gives us a pretty good lifeboat if we need to go back as the data is already in Oracle with the info we'd need to recreate a map.  Finally we could also tweak some of the older WCS reports to look at this info and they'd still essentially work.

