### PR TITLE
pass line1 and line2 values from resource to label printing method

### DIFF
--- a/src/Facade/Services/LogisticsProcessesFacadeService.cs
+++ b/src/Facade/Services/LogisticsProcessesFacadeService.cs
@@ -68,7 +68,9 @@
                         }
 
                         labelServiceResult = this.logisticsLabelService.PrintAddressLabel(
-                            resource.AddressId.Value, string.Empty, string.Empty,
+                            resource.AddressId.Value, 
+                            resource.Line1,
+                            resource.Line2,
                             resource.UserNumber,
                             resource.NumberOfCopies);
                     }


### PR DESCRIPTION
https://rndsupport.linn.co.uk/scp/tickets.php?id=18963

was there any reasonb why these things weren't being passed before?