### PR TITLE
allow message to show at least

### DIFF
--- a/src/Proxy/StoresPack.cs
+++ b/src/Proxy/StoresPack.cs
@@ -152,7 +152,7 @@
 
                 var result = new OracleParameter("G_ERR", OracleDbType.Varchar2)
                                  {
-                                     Direction = ParameterDirection.ReturnValue, Size = 50
+                                     Direction = ParameterDirection.ReturnValue, Size = 500
                                  };
                 cmd.Parameters.Add(result);
 


### PR DESCRIPTION
 - not a fix for the weird tpk issue - just noticed the errors were too long to make it back from the stored procedure