### PR TITLE
parts ut qc control overhaul

### DIFF
--- a/src/Domain.LinnApps/AuthorisedAction.cs
+++ b/src/Domain.LinnApps/AuthorisedAction.cs
@@ -4,6 +4,8 @@
     {
         public const string PartAdmin = "part.admin";
 
+        public const string PartQcController = "part.qc-controller";
+
         public const string WorkstationAdmin = "workstation.admin";
 
         public const string CreateStockLocator = "stock-locator.create";

--- a/src/Domain.LinnApps/Parts/IPartService.cs
+++ b/src/Domain.LinnApps/Parts/IPartService.cs
@@ -8,8 +8,6 @@
 
         Part CreatePart(Part partToCreate, List<string> privileges, bool fromTemplate);
 
-        void CheckCanChangeQc(List<string> privileges);
-
         void AddOnQcControl(string partNumber, int? createdBy, string qcInfo);
 
         Part CreateFromSource(int sourceId, int createdBy, IEnumerable<PartDataSheet> dataSheets);

--- a/src/Domain.LinnApps/Parts/IPartService.cs
+++ b/src/Domain.LinnApps/Parts/IPartService.cs
@@ -8,7 +8,7 @@
 
         Part CreatePart(Part partToCreate, List<string> privileges, bool fromTemplate);
 
-        void AddQcControl(string partNumber, int? createdBy, string qcInfo);
+        void AddOnQcControl(string partNumber, int? createdBy, string qcInfo);
 
         Part CreateFromSource(int sourceId, int createdBy, IEnumerable<PartDataSheet> dataSheets);
 

--- a/src/Domain.LinnApps/Parts/IPartService.cs
+++ b/src/Domain.LinnApps/Parts/IPartService.cs
@@ -8,6 +8,8 @@
 
         Part CreatePart(Part partToCreate, List<string> privileges, bool fromTemplate);
 
+        void CheckCanChangeQc(List<string> privileges);
+
         void AddOnQcControl(string partNumber, int? createdBy, string qcInfo);
 
         Part CreateFromSource(int sourceId, int createdBy, IEnumerable<PartDataSheet> dataSheets);

--- a/src/Domain.LinnApps/Parts/Part.cs
+++ b/src/Domain.LinnApps/Parts/Part.cs
@@ -206,44 +206,28 @@
 
         public DateTime? GetDateQcFlagLastChanged()
         {
-            if (this.QcOnReceipt == "Y")
-            {
-                var lastQcControl = this.QcControls.OrderByDescending(x => x.Id).FirstOrDefault();
-                if (lastQcControl != null && lastQcControl.OnOrOffQc == "ON")
-                {
-                    return lastQcControl.TransactionDate;
-                }
-            }
-
-            if (string.IsNullOrEmpty(this.QcOnReceipt) || this.QcOnReceipt == "N")
-            {
-                var lastQcControl = this.QcControls.OrderByDescending(x => x.Id).FirstOrDefault();
-                if (lastQcControl != null && lastQcControl.OnOrOffQc == "OFF")
-                {
-                    return lastQcControl.TransactionDate;
-                }
-            }
-
-            return null;
+            return this.GetRelevantQcControl()?.TransactionDate;
         }
 
         public Employee GetQcFlagLastChangedBy()
         {
-            if (this.QcOnReceipt == "Y")
+            return this.GetRelevantQcControl()?.Employee;
+        }
+
+        private QcControl GetRelevantQcControl()
+        {
+            var lastQcControl = this.QcControls.OrderByDescending(x => x.Id).FirstOrDefault();
+
+            if (this.QcOnReceipt == "Y" && lastQcControl?.OnOrOffQc == "ON")
             {
-                var lastQcControl = this.QcControls.OrderByDescending(x => x.Id).FirstOrDefault();
-                if (lastQcControl != null && lastQcControl.OnOrOffQc == "ON")
-                {
-                    return lastQcControl.Employee;
-                }
+                return lastQcControl;
             }
 
             if (string.IsNullOrEmpty(this.QcOnReceipt) || this.QcOnReceipt == "N")
             {
-                var lastQcControl = this.QcControls.OrderByDescending(x => x.Id).FirstOrDefault();
-                if (lastQcControl != null && lastQcControl.OnOrOffQc == "OFF")
+                if (lastQcControl?.OnOrOffQc == "OFF")
                 {
-                    return lastQcControl.Employee;
+                    return lastQcControl;
                 }
             }
 

--- a/src/Domain.LinnApps/Parts/Part.cs
+++ b/src/Domain.LinnApps/Parts/Part.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using Linn.Stores.Domain.LinnApps.StockLocators;
 
@@ -202,5 +203,51 @@
         public string AltiumValueRkm { get; set; }
 
         public decimal? ResistorTolerance { get; set; }
+
+        public DateTime? GetDateQcFlagLastChanged()
+        {
+            if (this.QcOnReceipt == "Y")
+            {
+                var lastQcControl = this.QcControls.OrderByDescending(x => x.Id).FirstOrDefault();
+                if (lastQcControl != null && lastQcControl.OnOrOffQc == "ON")
+                {
+                    return lastQcControl.TransactionDate;
+                }
+            }
+
+            if (string.IsNullOrEmpty(this.QcOnReceipt) || this.QcOnReceipt == "N")
+            {
+                var lastQcControl = this.QcControls.OrderByDescending(x => x.Id).FirstOrDefault();
+                if (lastQcControl != null && lastQcControl.OnOrOffQc == "OFF")
+                {
+                    return lastQcControl.TransactionDate;
+                }
+            }
+
+            return null;
+        }
+
+        public Employee GetQcFlagLastChangedBy()
+        {
+            if (this.QcOnReceipt == "Y")
+            {
+                var lastQcControl = this.QcControls.OrderByDescending(x => x.Id).FirstOrDefault();
+                if (lastQcControl != null && lastQcControl.OnOrOffQc == "ON")
+                {
+                    return lastQcControl.Employee;
+                }
+            }
+
+            if (string.IsNullOrEmpty(this.QcOnReceipt) || this.QcOnReceipt == "N")
+            {
+                var lastQcControl = this.QcControls.OrderByDescending(x => x.Id).FirstOrDefault();
+                if (lastQcControl != null && lastQcControl.OnOrOffQc == "OFF")
+                {
+                    return lastQcControl.Employee;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Domain.LinnApps/Parts/PartService.cs
+++ b/src/Domain.LinnApps/Parts/PartService.cs
@@ -121,11 +121,7 @@
             var notCurrentlyOnQc = string.IsNullOrEmpty(from.QcOnReceipt) || from.QcOnReceipt != "Y";
             if (notCurrentlyOnQc && to.QcOnReceipt.Equals("Y"))
             {
-                if (!this.authService.HasPermissionFor(AuthorisedAction.PartQcController, privileges))
-                {
-                    throw new UpdatePartException("You are not authorised to put parts on QC");
-                }
-
+                this.CheckCanChangeQc(privileges);
                 from.QcOnReceipt = "Y";
                 from.QcInformation = to.QcInformation;
                 this.AddOnQcControl(to.PartNumber, who, to.QcInformation);
@@ -135,11 +131,7 @@
             var currentlyOnQc = from.QcOnReceipt == "Y";
             if (currentlyOnQc && (string.IsNullOrEmpty(to.QcOnReceipt) || !to.QcOnReceipt.Equals("Y")))
             {
-                if (!this.authService.HasPermissionFor(AuthorisedAction.PartQcController, privileges))
-                {
-                    throw new UpdatePartException("You are not authorised to take parts off QC");
-                }
-
+                this.CheckCanChangeQc(privileges);
                 from.QcOnReceipt = "N";
                 from.QcInformation = to.QcInformation;
                 this.AddOffQcControl(to.PartNumber, who, to.QcInformation);
@@ -273,6 +265,14 @@
             this.Validate(partToCreate);
 
             return partToCreate;
+        }
+
+        public void CheckCanChangeQc(List<string> privileges)
+        {
+            if (!this.authService.HasPermissionFor(AuthorisedAction.PartQcController, privileges))
+            {
+                throw new UpdatePartException("You are not authorised to change parts QC status");
+            }
         }
 
         public void AddOnQcControl(string partNumber, int? createdBy, string qcInfo)

--- a/src/Domain.LinnApps/Parts/PartService.cs
+++ b/src/Domain.LinnApps/Parts/PartService.cs
@@ -267,7 +267,7 @@
             return partToCreate;
         }
 
-        public void CheckCanChangeQc(List<string> privileges)
+        private void CheckCanChangeQc(List<string> privileges)
         {
             if (!this.authService.HasPermissionFor(AuthorisedAction.PartQcController, privileges))
             {

--- a/src/Domain.LinnApps/Parts/PartService.cs
+++ b/src/Domain.LinnApps/Parts/PartService.cs
@@ -351,9 +351,10 @@
             part.LibraryName = source.LibraryName;
 
             var who = this.employeeRepository.FindById(createdBy);
-
+            var info = $"NEW PART - {who?.FullName}";
             part.QcOnReceipt = "Y";
-            this.AddOnQcControl(source.PartNumber, createdBy, $"NEW PART - {who?.FullName}");
+            part.QcInformation = info;
+            this.AddOnQcControl(source.PartNumber, createdBy, info);
 
             part.ResistorTolerance = source.ResistorTolerance;
 

--- a/src/Domain.LinnApps/Parts/PartService.cs
+++ b/src/Domain.LinnApps/Parts/PartService.cs
@@ -115,11 +115,9 @@
                 from.MadeLiveBy = to.MadeLiveBy;
             }
 
-            this.Validate(to);
-
             // putting a part on QC?
             var notCurrentlyOnQc = string.IsNullOrEmpty(from.QcOnReceipt) || from.QcOnReceipt != "Y";
-            if (notCurrentlyOnQc && to.QcOnReceipt.Equals("Y"))
+            if (notCurrentlyOnQc && !string.IsNullOrEmpty(to.QcOnReceipt) && to.QcOnReceipt.Equals("Y"))
             {
                 this.CheckCanChangeQc(privileges);
                 from.QcOnReceipt = "Y";
@@ -136,6 +134,8 @@
                 from.QcInformation = to.QcInformation;
                 this.AddOffQcControl(to.PartNumber, who, to.QcInformation);
             }
+
+            this.Validate(to);
 
             from.PhasedOutBy = to.PhasedOutBy;
             from.DatePhasedOut = to.DatePhasedOut;
@@ -279,7 +279,7 @@
         {
             if (string.IsNullOrEmpty(qcInfo))
             {
-                throw new CreatePartException("Must specify QC Information if setting part to be QC.");
+                throw new UpdatePartException("Must specify QC Information if setting part to be QC.");
             }
 
             this.qcControlRepository.Add(new QcControl
@@ -298,7 +298,7 @@
         {
             if (string.IsNullOrEmpty(qcInfo))
             {
-                throw new CreatePartException("Must specify a reasong (QC Information) if setting part to be off QC.");
+                throw new UpdatePartException("Must specify a reason (QC Information) if setting part to be off QC.");
             }
 
             this.qcControlRepository.Add(new QcControl

--- a/src/Facade/ResourceBuilders/PartResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/PartResourceBuilder.cs
@@ -14,7 +14,7 @@
 
         public PartResource Build(Part part)
         {
-            return new PartResource
+            var resource = new PartResource
                        {
                            Id = part.Id,
                            PartNumber = part.PartNumber,
@@ -131,7 +131,15 @@
                            SimModelName = part.SimModelName,
                            AltiumValue = part.AltiumValue,
                            ResistorTolerance = part.ResistorTolerance
-            };
+                       };
+
+            if (part.QcControls != null && part.QcControls.Any())
+            {
+                resource.DateQcFlagLastChanged = part.GetDateQcFlagLastChanged()?.ToString("o");
+                resource.WhoLastChangedQcFlag = part.GetQcFlagLastChangedBy()?.FullName;
+            }
+
+            return resource;
         }
 
         public string GetLocation(Part part)

--- a/src/Persistence.LinnApps/Repositories/PartRepository.cs
+++ b/src/Persistence.LinnApps/Repositories/PartRepository.cs
@@ -21,7 +21,9 @@
 
         public Part FindById(int key)
         {
-            var result = this.serviceDbContext.Parts.SingleOrDefault(p => p.Id == key);
+            var result = this.serviceDbContext.Parts
+                .Include(p => p.QcControls).ThenInclude(q => q.Employee)
+                .SingleOrDefault(p => p.Id == key);
 
             return result;
         }
@@ -89,6 +91,7 @@
                 .Include(p => p.PhasedOutBy)
                 .Include(p => p.SernosSequence)
                 .Include(p => p.PreferredSupplier)
+                .Include(p => p.QcControls).ThenInclude(q => q.Employee)
                 .Include(p => p.NominalAccount).ThenInclude(a => a.Department)
                 .Include(p => p.NominalAccount).ThenInclude(a => a.Nominal)
                 .Include(p => p.DataSheets)

--- a/src/Resources/Parts/PartResource.cs
+++ b/src/Resources/Parts/PartResource.cs
@@ -227,5 +227,9 @@
         public string AltiumValue { get; set; }
 
         public decimal? ResistorTolerance { get; set; }
+
+        public string WhoLastChangedQcFlag { get; set; }
+
+        public string DateQcFlagLastChanged { get; set; }
     }
 }

--- a/src/Service.Host/client/src/components/parts/Part.js
+++ b/src/Service.Host/client/src/components/parts/Part.js
@@ -471,6 +471,8 @@ function Part({
                                     tqmsCategoryOverride={state.part.tqmsCategoryOverride}
                                     stockNotes={state.part.stockNotes}
                                     plannerStory={state.part.plannerStory}
+                                    dateQcFlagLastChanged={state.part.dateQcFlagLastChanged}
+                                    whoLastChangedQcFlag={state.part.whoLastChangedQcFlag}
                                 />
                             )}
                             {tab === 4 && (

--- a/src/Service.Host/client/src/components/parts/partReducer.js
+++ b/src/Service.Host/client/src/components/parts/partReducer.js
@@ -79,6 +79,16 @@ export default function partReducer(state = initialState, action) {
                     }
                 };
             }
+            if (action.fieldName === 'qcOnReceipt') {
+                return {
+                    ...state,
+                    part: {
+                        ...state.part,
+                        qcOnReceipt: action.payload,
+                        qcInformation: ''
+                    }
+                };
+            }
             if (action.fieldName === 'accountingCompany') {
                 const updated =
                     action.payload === 'RECORDS'

--- a/src/Service.Host/client/src/components/parts/tabs/StoresTab.js
+++ b/src/Service.Host/client/src/components/parts/tabs/StoresTab.js
@@ -38,7 +38,7 @@ function StoresTab({
                 <InputField
                     fullWidth
                     value={qcInformation}
-                    label="QC Info"
+                    label="QC Change Reason"
                     onChange={handleFieldChange}
                     propertyName="qcInformation"
                 />

--- a/src/Service.Host/client/src/components/parts/tabs/StoresTab.js
+++ b/src/Service.Host/client/src/components/parts/tabs/StoresTab.js
@@ -17,11 +17,13 @@ function StoresTab({
     tqmsCategoryOverride,
     stockNotes,
     tqmsCategories,
-    plannerStory
+    plannerStory,
+    dateQcFlagLastChanged,
+    whoLastChangedQcFlag
 }) {
     return (
         <Grid container spacing={3}>
-            <Grid item xs={4}>
+            <Grid item xs={2}>
                 <Dropdown
                     label="QC On Receipt"
                     propertyName="qcOnReceipt"
@@ -32,13 +34,35 @@ function StoresTab({
                     onChange={handleFieldChange}
                 />
             </Grid>
-            <Grid item xs={8}>
+            <Grid item xs={4}>
                 <InputField
                     fullWidth
                     value={qcInformation}
                     label="QC Info"
                     onChange={handleFieldChange}
                     propertyName="qcInformation"
+                />
+            </Grid>
+            <Grid item xs={3}>
+                <InputField
+                    fullWidth
+                    value={whoLastChangedQcFlag}
+                    label="Last Change By "
+                    onChange={handleFieldChange}
+                    propertyName="whoLastChangedQcFlag"
+                />
+            </Grid>
+            <Grid item xs={3}>
+                <InputField
+                    fullWidth
+                    value={
+                        dateQcFlagLastChanged
+                            ? new Date(dateQcFlagLastChanged).toLocaleDateString()
+                            : ''
+                    }
+                    label="Changed On"
+                    onChange={dateQcFlagLastChanged}
+                    propertyName="dateQcFlagLastChanged"
                 />
             </Grid>
             <Grid item xs={4}>
@@ -169,7 +193,9 @@ StoresTab.propTypes = {
     tqmsCategories: PropTypes.arrayOf(
         PropTypes.shape({ name: PropTypes.string, description: PropTypes.string })
     ),
-    plannerStory: PropTypes.string
+    plannerStory: PropTypes.string,
+    dateQcFlagLastChanged: PropTypes.string,
+    whoLastChangedQcFlag: PropTypes.string
 };
 
 StoresTab.defaultProps = {
@@ -185,7 +211,9 @@ StoresTab.defaultProps = {
     tqmsCategoryOverride: null,
     stockNotes: null,
     tqmsCategories: [],
-    plannerStory: null
+    plannerStory: null,
+    dateQcFlagLastChanged: null,
+    whoLastChangedQcFlag: null
 };
 
 export default StoresTab;

--- a/src/Service/Modules/PartsModule.cs
+++ b/src/Service/Modules/PartsModule.cs
@@ -226,11 +226,6 @@
             resource.CreatedBy = int.Parse(userId);
             try
             {
-                if (!string.IsNullOrEmpty(resource.QcOnReceipt) && resource.QcOnReceipt.Equals("Y"))
-                {
-                    this.partDomainService.CheckCanChangeQc(resource.UserPrivileges.ToList());
-                }
-
                 var result = this.partsFacadeService.Add(resource);
 
                 if (!string.IsNullOrEmpty(resource.QcOnReceipt) && resource.QcOnReceipt.Equals("Y"))

--- a/src/Service/Modules/PartsModule.cs
+++ b/src/Service/Modules/PartsModule.cs
@@ -230,6 +230,11 @@
 
                 if (!string.IsNullOrEmpty(resource.QcOnReceipt) && resource.QcOnReceipt.Equals("Y"))
                 {
+                    // bit of a hack, need to add QC_CONTROL after part is created and committed
+                    // but ideally this process would live in the domain
+                    // todo - could we refactor this to be in the domain?
+                    // e.g. just add a QcControl to the Parts ICollection<QcControl> QcControls
+                    // and let EFCore figure it out
                     this.partDomainService.AddOnQcControl(resource.PartNumber, resource.CreatedBy, resource.QcInformation);
                 }
 

--- a/src/Service/Modules/PartsModule.cs
+++ b/src/Service/Modules/PartsModule.cs
@@ -228,7 +228,7 @@
                 var result = this.partsFacadeService.Add(resource);
                 if (!string.IsNullOrEmpty(resource.QcOnReceipt) && resource.QcOnReceipt.Equals("Y"))
                 {
-                    this.partDomainService.AddQcControl(resource.PartNumber, resource.CreatedBy, resource.QcInformation);
+                    this.partDomainService.AddOnQcControl(resource.PartNumber, resource.CreatedBy, resource.QcInformation);
                 }
 
                 return this.Negotiate.WithModel(result)

--- a/stores.sln
+++ b/stores.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31702.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35506.116 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Domain", "src\Domain\Domain.csproj", "{309A3AD8-4D8A-411D-9C52-D6812EB7D776}"
 EndProject

--- a/tests/Integration/Service.Tests/PartsModuleSpecs/WhenAddingAndNotQcOnReceipt.cs
+++ b/tests/Integration/Service.Tests/PartsModuleSpecs/WhenAddingAndNotQcOnReceipt.cs
@@ -59,7 +59,7 @@
         public void ShouldNotAddQcInfo()
         {
             this.PartsDomainService.DidNotReceive()
-                .AddQcControl(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>());
+                .AddOnQcControl(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>());
         }
 
         [Test]

--- a/tests/Integration/Service.Tests/PartsModuleSpecs/WhenAddingAndQcOnReceipt.cs
+++ b/tests/Integration/Service.Tests/PartsModuleSpecs/WhenAddingAndQcOnReceipt.cs
@@ -65,7 +65,7 @@
         public void ShouldAddQcInfo()
         {
             this.PartsDomainService.Received()
-                .AddQcControl(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>());
+                .AddOnQcControl(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>());
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/ContextBase.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/ContextBase.cs
@@ -38,7 +38,7 @@
 
         protected IEmailService EmailService { get; private set; }
 
-        protected IQueryRepository<PhoneListEntry> PhoneList { get; set; }
+        protected IRepository<Employee, int> EmployeeRepository{ get; set; }
 
         [SetUp]
         public void SetUpContext()
@@ -55,7 +55,7 @@
             this.DataSheetRepository = Substitute.For<IRepository<PartDataSheet, PartDataSheetKey>>();
             this.DeptStockPartsService = Substitute.For<IDeptStockPartsService>();
             this.EmailService = Substitute.For<IEmailService>();
-            this.PhoneList = Substitute.For<IQueryRepository<PhoneListEntry>>();
+            this.EmployeeRepository = Substitute.For<IRepository<Employee, int>>();
 
             this.Sut = new PartService(
                 this.AuthService,
@@ -68,7 +68,7 @@
                 this.PartPack,
                 this.DeptStockPartsService,
                 this.EmailService,
-                this.PhoneList);
+                this.EmployeeRepository);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenCreatingElectricalPartFromSourceSheet.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenCreatingElectricalPartFromSourceSheet.cs
@@ -52,8 +52,10 @@
         public void ShouldAddQcControl()
         {
             this.result.QcOnReceipt.Should().Be("Y");
+            var expectedInfo = "NEW PART - MONSIEUR ENGINEER";
+            this.result.QcInformation.Should().Be(expectedInfo);
             this.QcControlRepo.Received(1).Add(
-                Arg.Is<QcControl>(x => x.Reason == "NEW PART - MONSIEUR ENGINEER"));
+                Arg.Is<QcControl>(x => x.Reason == expectedInfo));
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenCreatingElectricalPartFromSourceSheet.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenCreatingElectricalPartFromSourceSheet.cs
@@ -4,6 +4,8 @@
     using System.Collections.Generic;
     using System.Linq.Expressions;
 
+    using FluentAssertions;
+
     using Linn.Common.Configuration;
     using Linn.Stores.Domain.LinnApps.Parts;
 
@@ -13,18 +15,21 @@
 
     public class WhenCreatingElectricalPartFromSourceSheet : ContextBase
     {
+        private Part result;
+
         [SetUp]
         public void SetUp()
         {
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>()).Returns(new Part { PartNumber = "PART" });
             this.SourceRepository.FindById(1).Returns(new MechPartSource { PartNumber = "PART", MechanicalOrElectrical = "E", Id = 1 });
+            this.EmployeeRepository.FindById(33087).Returns(new Employee { FullName = "MONSIEUR ENGINEER" });
             this.PartPack.CreatePartFromSourceSheet(1, 33087, out var message).Returns(
                 x =>
                     {
                         x[2] = "Created part PART";
                         return "PART";
                     });
-            this.Sut.CreateFromSource(1, 33087, new List<PartDataSheet>());
+            this.result = this.Sut.CreateFromSource(1, 33087, new List<PartDataSheet>());
         }
 
         [Test]
@@ -41,6 +46,14 @@
                 "Click here to view: https://app.linn.co.uk/parts/sources/1",
                 null, 
                 null);
+        }
+
+        [Test]
+        public void ShouldAddQcControl()
+        {
+            this.result.QcOnReceipt.Should().Be("Y");
+            this.QcControlRepo.Received(1).Add(
+                Arg.Is<QcControl>(x => x.Reason == "NEW PART - MONSIEUR ENGINEER"));
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenPuttingPartOnQc.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenPuttingPartOnQc.cs
@@ -1,0 +1,59 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.PartServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Parts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenPuttingPartOnQc : ContextBase
+    {
+        private Part to;
+
+        private Part from;
+
+        private List<string> privileges;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.from = new Part();
+            this.to = new Part
+                          {
+                              PartNumber = "PART",
+                              RawOrFinished = "R",
+                              QcOnReceipt = "Y",
+                              QcInformation = "Making it QC"
+                          };
+            this.privileges = new List<string> { "part.admin", "part.qc-controller" };
+            this.PartPack.PartLiveTest(Arg.Any<string>(), out _).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartAdmin, this.privileges).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartQcController, this.privileges).Returns(true);
+
+            this.Sut.UpdatePart(this.from, this.to, this.privileges, 33087);
+        }
+
+        [Test]
+        public void ShouldUpdate()
+        {
+            this.from.QcOnReceipt.Should().Be(this.to.QcOnReceipt);
+            this.from.QcInformation.Should().Be(this.to.QcInformation);
+        }
+
+        [Test]
+        public void ShouldAddQcControlRecord()
+        {
+            this.QcControlRepo.Received().Add(Arg.Is<QcControl>(x => 
+                x.PartNumber == this.to.PartNumber
+                && x.OnOrOffQc == "ON"
+                && x.ChangedBy == 33087
+                && x.TransactionDate == DateTime.Today.Date
+                && x.Reason == this.to.QcInformation));
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenPuttingPartOnQcAndNoReasonGiven.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenPuttingPartOnQcAndNoReasonGiven.cs
@@ -1,0 +1,58 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.PartServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Exceptions;
+    using Linn.Stores.Domain.LinnApps.Parts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenPuttingPartOnQcAndNoReasonGiven : ContextBase
+    {
+        private Part to;
+
+        private Part from;
+
+        private List<string> privileges;
+
+        private Action act;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.from = new Part { QcOnReceipt = null };
+            this.to = new Part
+                          {
+                              PartNumber = "PART",
+                              RawOrFinished = "R",
+                              QcOnReceipt = "Y",
+                              QcInformation = string.Empty
+                          };
+            this.privileges = new List<string> { "part.admin", "part.qc-controller" };
+            this.PartPack.PartLiveTest(Arg.Any<string>(), out _).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartAdmin, this.privileges).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartQcController, this.privileges).Returns(true);
+
+            this.act = () => this.Sut.UpdatePart(this.from, this.to, this.privileges, 33087);
+        }
+
+        [Test]
+        public void ShouldNotUpdate()
+        {
+            this.from.QcOnReceipt.Should().NotBe("Y");
+            this.from.QcInformation.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void ShouldThrow()
+        {
+            this.act.Should().Throw<UpdatePartException>()
+                .WithMessage("Must specify QC Information if setting part to be QC.");
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenPuttingPartOnQcAndUnauthorised.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenPuttingPartOnQcAndUnauthorised.cs
@@ -1,0 +1,56 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.PartServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Exceptions;
+    using Linn.Stores.Domain.LinnApps.Parts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenPuttingPartOnQcAndUnauthorised : ContextBase
+    {
+        private Part to;
+
+        private Part from;
+
+        private List<string> privileges;
+
+        private Action act;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.from = new Part();
+            this.to = new Part
+                          {
+                              PartNumber = "PART",
+                              RawOrFinished = "R",
+                              QcOnReceipt = "Y",
+                              QcInformation = "Making it QC"
+                          };
+            this.privileges = new List<string> { "part.admin", "part.qc-controller" };
+            this.PartPack.PartLiveTest(Arg.Any<string>(), out _).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartAdmin, this.privileges).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartQcController, this.privileges).Returns(false);
+
+            this.act = () => this.Sut.UpdatePart(this.from, this.to, this.privileges, 33087);
+        }
+
+        [Test]
+        public void ShouldNotUpdate()
+        {
+            this.from.QcOnReceipt.Should().NotBe("Y");
+        }
+
+        [Test]
+        public void ShouldThrow()
+        {
+            this.act.Should().Throw<UpdatePartException>().WithMessage("You are not authorised to put parts on QC");
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenPuttingPartOnQcAndUnauthorised.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenPuttingPartOnQcAndUnauthorised.cs
@@ -50,7 +50,7 @@
         [Test]
         public void ShouldThrow()
         {
-            this.act.Should().Throw<UpdatePartException>().WithMessage("You are not authorised to put parts on QC");
+            this.act.Should().Throw<UpdatePartException>().WithMessage("You are not authorised to change parts QC status");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenTakingPartOffQc.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenTakingPartOffQc.cs
@@ -11,7 +11,7 @@
 
     using NUnit.Framework;
 
-    public class WhenUpdatingPartToBeQc : ContextBase
+    public class WhenTakingPartOffQc : ContextBase
     {
         private Part to;
 
@@ -22,33 +22,35 @@
         [SetUp]
         public void SetUp()
         {
-            this.from = new Part();
+            this.from = new Part { QcOnReceipt = "Y", QcInformation = "NEW SUPPLIER" };
             this.to = new Part
                           {
                               PartNumber = "PART",
                               RawOrFinished = "R",
-                              QcOnReceipt = "Y",
-                              QcInformation = "Making it QC"
+                              QcOnReceipt = "N",
+                              QcInformation = "ALL GOOD"
                           };
-            this.privileges = new List<string> { "part.admin" };
+            this.privileges = new List<string> { "part.admin", "part.qc-controller" };
             this.PartPack.PartLiveTest(Arg.Any<string>(), out _).Returns(true);
             this.AuthService.HasPermissionFor(AuthorisedAction.PartAdmin, this.privileges).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartQcController, this.privileges).Returns(true);
+
             this.Sut.UpdatePart(this.from, this.to, this.privileges, 33087);
         }
 
         [Test]
         public void ShouldUpdate()
         {
-            this.from.QcOnReceipt.Should().Be(this.to.QcOnReceipt);
+            this.from.QcOnReceipt.Should().Be("N");
             this.from.QcInformation.Should().Be(this.to.QcInformation);
         }
 
         [Test]
         public void ShouldAddQcControlRecord()
         {
-            this.QcControlRepo.Received().Add(Arg.Is<QcControl>(x => 
+            this.QcControlRepo.Received().Add(Arg.Is<QcControl>(x =>
                 x.PartNumber == this.to.PartNumber
-                && x.OnOrOffQc == "ON"
+                && x.OnOrOffQc == "OFF"
                 && x.ChangedBy == 33087
                 && x.TransactionDate == DateTime.Today.Date
                 && x.Reason == this.to.QcInformation));

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenTakingPartOffQcAndNoReasonGiven.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenTakingPartOffQcAndNoReasonGiven.cs
@@ -1,0 +1,58 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.PartServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Exceptions;
+    using Linn.Stores.Domain.LinnApps.Parts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenTakingPartOffQcAndNoReasonGiven : ContextBase
+    {
+        private Part to;
+
+        private Part from;
+
+        private List<string> privileges;
+
+        private Action act;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.from = new Part { QcOnReceipt = "Y", QcInformation = "NEW SUPPLIER" };
+            this.to = new Part
+                          {
+                              PartNumber = "PART",
+                              RawOrFinished = "R",
+                              QcOnReceipt = "N",
+                              QcInformation = string.Empty
+                          };
+            this.privileges = new List<string> { "part.admin", "part.qc-controller" };
+            this.PartPack.PartLiveTest(Arg.Any<string>(), out _).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartAdmin, this.privileges).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartQcController, this.privileges).Returns(true);
+
+            this.act = () => this.Sut.UpdatePart(this.from, this.to, this.privileges, 33087);
+        }
+
+        [Test]
+        public void ShouldNotUpdate()
+        {
+            this.from.QcOnReceipt.Should().Be("Y");
+            this.from.QcInformation.Should().Be("NEW SUPPLIER");
+        }
+
+        [Test]
+        public void ShouldThrow()
+        {
+            this.act.Should().Throw<UpdatePartException>()
+                .WithMessage("Must specify a reason (QC Information) if setting part to be off QC.");
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenTakingPartOffQcAndUnauthorised.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenTakingPartOffQcAndUnauthorised.cs
@@ -1,0 +1,57 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.PartServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Exceptions;
+    using Linn.Stores.Domain.LinnApps.Parts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenTakingPartOffQcAndUnauthorised : ContextBase
+    {
+        private Part to;
+
+        private Part from;
+
+        private List<string> privileges;
+
+        private Action act;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.from = new Part { QcOnReceipt = "Y", QcInformation = "NEW SUPPLIER" };
+            this.to = new Part
+                          {
+                              PartNumber = "PART",
+                              RawOrFinished = "R",
+                              QcOnReceipt = "N",
+                              QcInformation = "ALL GOOD"
+                          };
+            this.privileges = new List<string> { "part.admin", "part.qc-controller" };
+            this.PartPack.PartLiveTest(Arg.Any<string>(), out _).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartAdmin, this.privileges).Returns(true);
+            this.AuthService.HasPermissionFor(AuthorisedAction.PartQcController, this.privileges).Returns(false);
+
+            this.act = () => this.Sut.UpdatePart(this.from, this.to, this.privileges, 33087);
+        }
+
+        [Test]
+        public void ShouldNotUpdate()
+        {
+            this.from.QcOnReceipt.Should().Be("Y");
+            this.from.QcInformation.Should().Be("NEW SUPPLIER");
+        }
+
+        [Test]
+        public void ShouldThrow()
+        {
+            this.act.Should().Throw<UpdatePartException>("You are not authorised to take parts off QC");
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenTakingPartOffQcAndUnauthorised.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartServiceTests/WhenTakingPartOffQcAndUnauthorised.cs
@@ -51,7 +51,7 @@
         [Test]
         public void ShouldThrow()
         {
-            this.act.Should().Throw<UpdatePartException>("You are not authorised to take parts off QC");
+            this.act.Should().Throw<UpdatePartException>().WithMessage("You are not authorised to change parts QC status");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PartTests/WhenGettingLastChangeInfoAndPartIsNotOnQc.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartTests/WhenGettingLastChangeInfoAndPartIsNotOnQc.cs
@@ -1,0 +1,64 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.PartTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Parts;
+
+    using NUnit.Framework;
+
+    public class WhenGettingLastChangeInfoAndPartIsNotOnQc
+    {
+        private Part sut;
+        private DateTime? resultDate;
+        private Employee resultEmployee;
+        private DateTime expectedDate;
+        private Employee expectedEmployee;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.expectedEmployee = new Employee { FullName = "Test Employee" };
+            this.expectedDate = new DateTime(2025, 1, 1);
+
+            this.sut = new Part
+                           {
+                               QcOnReceipt = "N",
+                               QcControls = new List<QcControl>
+                                                {
+                                                    new QcControl
+                                                        {
+                                                            Id = 1,
+                                                            OnOrOffQc = "ON",
+                                                            TransactionDate = new DateTime(2024, 1, 1),
+                                                            Employee = new Employee()
+                                                        },
+                                                    new QcControl
+                                                        {
+                                                            Id = 2,
+                                                            OnOrOffQc = "OFF",
+                                                            TransactionDate = this.expectedDate,
+                                                            Employee = this.expectedEmployee
+                                                        }
+                                                }
+                           };
+
+            this.resultDate = this.sut.GetDateQcFlagLastChanged();
+            this.resultEmployee = this.sut.GetQcFlagLastChangedBy();
+        }
+
+        [Test]
+        public void ShouldReturnDate()
+        {
+            this.resultDate.Should().Be(this.expectedDate);
+        }
+
+        [Test]
+        public void ShouldReturnEmployee()
+        {
+            this.resultEmployee.Should().Be(this.expectedEmployee);
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/PartTests/WhenGettingLastChangeInfoAndPartIsNotOnQcButLatestControlIsNotOff.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartTests/WhenGettingLastChangeInfoAndPartIsNotOnQcButLatestControlIsNotOff.cs
@@ -1,0 +1,59 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.PartTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Parts;
+
+    using NUnit.Framework;
+
+    public class WhenGettingLastChangeInfoAndPartIsNotOnQcButLatestControlIsNotOff
+    {
+        private Part sut;
+        private DateTime? resultDate;
+        private Employee resultEmployee;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.sut = new Part
+                           {
+                               QcOnReceipt = "N",
+                               QcControls = new List<QcControl>
+                                                {
+                                                    new QcControl
+                                                        {
+                                                            Id = 1,
+                                                            OnOrOffQc = "ON",
+                                                            TransactionDate = new DateTime(2024, 1, 1),
+                                                            Employee = new Employee { FullName = "Employee One" }
+                                                        },
+                                                    new QcControl
+                                                        {
+                                                            Id = 2,
+                                                            OnOrOffQc = "ON",
+                                                            TransactionDate = new DateTime(2025, 1, 1),
+                                                            Employee = new Employee { FullName = "Employee Two" }
+                                                        }
+                                                }
+                           };
+
+            this.resultDate = this.sut.GetDateQcFlagLastChanged();
+            this.resultEmployee = this.sut.GetQcFlagLastChangedBy();
+        }
+
+        [Test]
+        public void ShouldReturnNullDate()
+        {
+            this.resultDate.Should().BeNull();
+        }
+
+        [Test]
+        public void ShouldReturnNullEmployee()
+        {
+            this.resultEmployee.Should().BeNull();
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/PartTests/WhenGettingLastChangeInfoAndPartIsOnQc.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartTests/WhenGettingLastChangeInfoAndPartIsOnQc.cs
@@ -1,0 +1,63 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.PartTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Parts;
+
+    using NUnit.Framework;
+
+    public class WhenGettingLastChangeInfoAndPartIsOnQc
+    {
+        private Part sut;
+        private DateTime? resultDate;
+        private Employee resultEmployee;
+        private DateTime expectedDate;
+        private Employee expectedEmployee;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.expectedEmployee = new Employee { FullName = "Test Employee" };
+            this.expectedDate = new DateTime(2025, 1, 1);
+
+            this.sut = new Part
+                           {
+                               QcOnReceipt = "Y",
+                               QcControls = new List<QcControl>
+                                                {
+                                                    new QcControl
+                                                        {
+                                                            Id = 1, 
+                                                            OnOrOffQc = "OFF", 
+                                                            TransactionDate = new DateTime(2024, 1, 1), Employee = new Employee()
+                                                        },
+                                                    new QcControl
+                                                        {
+                                                            Id = 2, 
+                                                            OnOrOffQc = "ON", 
+                                                            TransactionDate = this.expectedDate, 
+                                                            Employee = this.expectedEmployee
+                                                        }
+                                                }
+                           };
+
+            this.resultDate = this.sut.GetDateQcFlagLastChanged();
+            this.resultEmployee = this.sut.GetQcFlagLastChangedBy();
+        }
+
+        [Test]
+        public void ShouldReturnDate()
+        {
+            this.resultDate.Should().Be(this.expectedDate);
+        }
+
+        [Test]
+        public void ShouldReturnEmployee()
+        {
+            this.resultEmployee.Should().Be(this.expectedEmployee);
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/PartTests/WhenGettingLastChangeInfoAndPartIsOnQcButLatestControlIsNotOn.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PartTests/WhenGettingLastChangeInfoAndPartIsOnQcButLatestControlIsNotOn.cs
@@ -1,0 +1,59 @@
+﻿namespace Linn.Stores.Domain.LinnApps.Tests.PartTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+
+    using Linn.Stores.Domain.LinnApps.Parts;
+
+    using NUnit.Framework;
+
+    public class WhenGettingLastChangeInfoAndPartIsOnQcButLatestControlIsNotOn
+    {
+        private Part sut;
+        private DateTime? resultDate;
+        private Employee resultEmployee;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.sut = new Part
+                           {
+                               QcOnReceipt = "Y",
+                               QcControls = new List<QcControl>
+                                                {
+                                                    new QcControl
+                                                        {
+                                                            Id = 1,
+                                                            OnOrOffQc = "OFF",
+                                                            TransactionDate = new DateTime(2024, 1, 1),
+                                                            Employee = new Employee { FullName = "Some Employee" }
+                                                        },
+                                                    new QcControl
+                                                        {
+                                                            Id = 2,
+                                                            OnOrOffQc = "OFF",
+                                                            TransactionDate = new DateTime(2025, 1, 1),
+                                                            Employee = new Employee { FullName = "Another Employee" }
+                                                        }
+                                                }
+                           };
+
+            this.resultDate = this.sut.GetDateQcFlagLastChanged();
+            this.resultEmployee = this.sut.GetQcFlagLastChangedBy();
+        }
+
+        [Test]
+        public void ShouldReturnNullDate()
+        {
+            this.resultDate.Should().BeNull();
+        }
+
+        [Test]
+        public void ShouldReturnNullEmployee()
+        {
+            this.resultEmployee.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
- this PR tries to rejuvenate the QC_CONTROL table to track changes to parts QC_ON_RECEIPT status
- Since I didn't ever quite fully support this when I first replaced parts utility (I only added QC_CONTROL  table entries when parts went on QC... not when they went off QC) the history is a little spotty, but going forward things should be better (i.e. every part should have a complete QC_CONTROL history from now on)
- it also introduces some new auth - only authorised users can change QC_ON_RECEIPT after a part is created (during creation it can still be set to Y/N by the user)
- also streamlined creations from source sheets to default to QC_ON_RECEIPT = Y and set the QC_INFORMATION field appropriately - as it stands the users are just dilligently remembering to do this
- also need to kill these old linnapps pages https://app.linn.co.uk/stores/qc/startinspecting.aspx , https://app.linn.co.uk/stores/qc/stopinspecting.aspx as as it stands they provide a backdoor to bypass the new auth
